### PR TITLE
Refactor user creation to use parameterized queries

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -18,7 +18,8 @@ export class AuthController{
         const usuario= await this.userService.login(dto.email, dto.password);
         if(!usuario)
             throw Error("Usuario no encontrado");
-        const userProfile = {id: usuario.id.toString(), email: usuario.email, name: usuario.name};
+        const userName = `${usuario.first_name} ${usuario.last_name}`.trim() || usuario.username;
+        const userProfile = {id: usuario.id.toString(), email: usuario.email, name: userName};
         const accessToken = await this.tokenService.generateAccess(userProfile);
         const refreshToken= await this.tokenService.generateRefresh(usuario.id.toString());
         return { accessToken, refreshToken };
@@ -37,7 +38,8 @@ export class AuthController{
             const profile= await this.tokenService.verifyRefresh(dto.refreshToken);
             const user= await this.userService.findById(Number(profile.sub));
             if(!user) throw Error("Usuario no encontrado");
-            const newAccessToken = await this.tokenService.generateAccess({id: user.id.toString(), email: user.email, name: user.name});
+            const userName = `${user.first_name} ${user.last_name}`.trim() || user.username;
+            const newAccessToken = await this.tokenService.generateAccess({id: user.id.toString(), email: user.email, name: userName});
             return {accessToken: newAccessToken};
         }catch{
             throw Error("Token de refresco inválido");

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,0 +1,27 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiProperty } from "@nestjs/swagger";
+import { UserRole } from "../user.repository";
+
+export class CreateUserDto {
+    @ApiProperty({ example: "user@example.com", description: "Email del usuario" })
+    email: string;
+
+    @ApiProperty({ example: "user123", description: "Nombre de usuario único" })
+    username: string;
+
+    @ApiProperty({ example: "Juan", description: "Nombre del usuario" })
+    firstName: string;
+
+    @ApiProperty({ example: "Pérez", description: "Apellido del usuario" })
+    lastName: string;
+
+    @ApiProperty({ example: "+34999888777", description: "Teléfono de contacto", required: false })
+    phoneNumber?: string;
+
+    @ApiProperty({ example: "password123", description: "Contraseña del usuario" })
+    password: string;
+
+    @ApiProperty({ enum: ["user", "admin", "moderator"], required: false, description: "Rol del usuario" })
+    role?: UserRole;
+}

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -1,28 +1,20 @@
 /* eslint-disable prettier/prettier */
 
 import { Body, Controller, Post } from "@nestjs/common";
-import { UserDto, UserService } from "./user.service";
-import { ApiProperty, ApiResponse, ApiTags } from "@nestjs/swagger";
-
-export class CreateUserDto{
-    @ApiProperty({example:"user@example.com", description:"Email del usuario"})
-    email: string;
-    @ApiProperty({example:"Usuario Ejemplo", description:"Nombre del usuario", required:false})
-    name: string;
-    @ApiProperty({example:"password123", description:"Contraseña del usuario"})
-    password: string;
-}
+import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { CreateUserDto } from "./dto/create-user.dto";
+import { User } from "./user.repository";
+import { UserService } from "./user.service";
 
 @ApiTags("Endpoints de Usuarios")
 @Controller("users")
-export class UserController{
+export class UserController {
     constructor(private readonly userService: UserService) {}
 
     @Post()
-    @ApiResponse({status: 201, description: "Usuario creado exitosamente"})
-    @ApiResponse({status: 500, description: "Error interno del servidor"})
-    async registerUser(@Body() userDto: CreateUserDto): Promise<UserDto|void> {
-        return this.userService.registerUser(userDto.email, userDto.name, userDto.password);
+    @ApiResponse({ status: 201, description: "Usuario creado exitosamente" })
+    @ApiResponse({ status: 500, description: "Error interno del servidor" })
+    async registerUser(@Body() userDto: CreateUserDto): Promise<User> {
+        return this.userService.registerUser(userDto);
     }
-
 }

--- a/src/users/user.repository.ts
+++ b/src/users/user.repository.ts
@@ -1,39 +1,86 @@
 /* eslint-disable prettier/prettier */
 
 import { Injectable } from "@nestjs/common";
+import { ResultSetHeader, RowDataPacket } from "mysql2";
 import { DbService } from "src/db/db.service";
 
-export type User= {
+export type UserRole = "user" | "admin" | "moderator";
+
+export type User = {
     id: number;
     email: string;
-    name: string;
+    username: string;
+    first_name: string;
+    last_name: string;
+    phone_number: string | null;
     password_hash: string;
-    salt: string;
-}
+    password_salt: string;
+    role: UserRole;
+    is_blocked: number | boolean;
+    blocked_reason: string | null;
+    blocked_by: number | null;
+    blocked_at: Date | null;
+    privacy_accepted_at: Date | null;
+    community_rules_accepted_at: Date | null;
+    last_login_at: Date | null;
+    created_at: Date;
+    updated_at: Date;
+    deleted_at: Date | null;
+};
 
+export type CreateUserRecord = {
+    email: string;
+    username: string;
+    first_name: string;
+    last_name: string;
+    phone_number?: string | null;
+    password_hash: string;
+    password_salt: string;
+    role?: UserRole;
+};
 
 @Injectable()
-export class UserRepository{
+export class UserRepository {
     constructor(private readonly dbService: DbService) {}
 
-    async registerUser(email:string, 
-        name:string, password:string):Promise<User|void>{
-        const sql= `INSERT INTO users (email,name,password_hash,salt) VALUES ('${email}','${name}','${password}','saltTest')`;
-        await this.dbService.getPool().query(sql);
+    async registerUser(data: CreateUserRecord): Promise<User> {
+        const insertSql =
+            "INSERT INTO users (email, username, first_name, last_name, phone_number, password_hash, password_salt, role) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
+        const pool = this.dbService.getPool();
+        const [result] = await pool.execute<ResultSetHeader>(insertSql, [
+            data.email,
+            data.username,
+            data.first_name,
+            data.last_name,
+            data.phone_number ?? null,
+            data.password_hash,
+            data.password_salt,
+            data.role ?? "user",
+        ]);
+
+        const createdUser = await this.findById(result.insertId);
+        if (!createdUser) {
+            throw new Error("Failed to retrieve created user");
+        }
+
+        return createdUser;
     }
 
-    async findByEmail(email:string):Promise<User>{
-        const sql= `SELECT * FROM users WHERE email='${email}' LIMIT 1`;
-        const [rows]= await this.dbService.getPool().query(sql);
-        const result= rows as User[];
-        return result[0];
+    async findByEmail(email: string): Promise<User | null> {
+        const sql = "SELECT * FROM users WHERE email = ? LIMIT 1";
+        const [rows] = await this.dbService
+            .getPool()
+            .execute<RowDataPacket[]>(sql, [email]);
+        const users = rows as unknown as User[];
+        return users.length > 0 ? users[0] : null;
     }
-    async findById(id:number):Promise<User>{
-        const sql= `SELECT * FROM users WHERE id='${id}' LIMIT 1`;
-        const [rows]= await this.dbService.getPool().query(sql);
-        const result= rows as User[];
-        return result[0];
+
+    async findById(id: number): Promise<User | null> {
+        const sql = "SELECT * FROM users WHERE id = ? LIMIT 1";
+        const [rows] = await this.dbService
+            .getPool()
+            .execute<RowDataPacket[]>(sql, [id]);
+        const users = rows as unknown as User[];
+        return users.length > 0 ? users[0] : null;
     }
 }
-
-

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -1,35 +1,57 @@
 /* eslint-disable prettier/prettier */
 
-import { Injectable, UnauthorizedException } from "@nestjs/common";
-import { User, UserRepository } from "./user.repository";
+import { ConflictException, Injectable, UnauthorizedException } from "@nestjs/common";
+import { randomBytes } from "crypto";
 import { sha256 } from "src/util/crypto/hash.util";
-
-export type UserDto={
-    email: string;
-    name: string;
-}
+import { CreateUserDto } from "./dto/create-user.dto";
+import { User, UserRepository } from "./user.repository";
 
 @Injectable()
 export class UserService {
     constructor(private readonly userRepository: UserRepository) {}
 
-    async registerUser(email:string, name:string, password:string):Promise<UserDto|void>{
-        console.log("Aqui hacemos el hash del password")
-        const hashedPassword = sha256(password);
-        return this.userRepository.registerUser(email, name, hashedPassword);
+    async registerUser(createUserDto: CreateUserDto): Promise<User> {
+        const salt = randomBytes(16).toString("hex");
+        const hashedPassword = sha256(`${createUserDto.password}${salt}`);
+
+        try {
+            return await this.userRepository.registerUser({
+                email: createUserDto.email,
+                username: createUserDto.username,
+                first_name: createUserDto.firstName,
+                last_name: createUserDto.lastName,
+                phone_number: createUserDto.phoneNumber ?? null,
+                password_hash: hashedPassword,
+                password_salt: salt,
+                role: createUserDto.role ?? "user",
+            });
+        } catch (error) {
+            if (this.isDuplicateEntryError(error)) {
+                throw new ConflictException("El email o nombre de usuario ya existe");
+            }
+            throw error;
+        }
     }
 
-    async login(email:string, password:string):Promise<User>{
-        const user= await this.userRepository.findByEmail(email);
-        if(!user) throw Error("Usuario no encontrado");
-        if(user.password_hash !== sha256(password)){
+    async login(email: string, password: string): Promise<User> {
+        const user = await this.userRepository.findByEmail(email);
+        if (!user) throw Error("Usuario no encontrado");
+        if (user.password_hash !== sha256(`${password}${user.password_salt}`)) {
             throw new UnauthorizedException("Contraseña incorrecta");
         }
         return user;
     }
 
-    async findById(id:number):Promise<User>{
+    async findById(id: number): Promise<User | null> {
         return this.userRepository.findById(id);
     }
 
+    private isDuplicateEntryError(error: unknown): boolean {
+        return (
+            typeof error === "object" &&
+            error !== null &&
+            "code" in error &&
+            (error as { code?: string }).code === "ER_DUP_ENTRY"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- update the user repository to use parameterized SQL and return the created record aligned with the latest schema
- expand the user creation DTO and service to capture username and profile details while generating password salt and hash
- surface duplicate email or username errors and adapt authentication responses to the new user fields

## Testing
- npm run lint *(fails: existing lint errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d9e6934d60832ba1865c7d12c659a5