### PR TITLE
Restrict user creation role options to user and admin

### DIFF
--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,6 +1,7 @@
 /* eslint-disable prettier/prettier */
 
 import { ApiProperty } from "@nestjs/swagger";
+import { IsIn } from "class-validator";
 import type { UserRole } from "../user.repository";
 
 export class CreateUserDto {
@@ -22,6 +23,7 @@ export class CreateUserDto {
     @ApiProperty({ example: "password123", description: "Contraseña del usuario" })
     password: string;
 
-    @ApiProperty({ enum: ["user", "admin", "moderator"], required: false, description: "Rol del usuario" })
+    @ApiProperty({ enum: ["user", "admin"], required: false, description: "Rol del usuario" })
+    @IsIn(["user", "admin"])
     role?: UserRole;
 }


### PR DESCRIPTION
## Summary
- remove the deprecated moderator value from the CreateUserDto Swagger enum so only user and admin appear
- guard the optional role field with an IsIn validator to keep requests aligned with the available roles

## Testing
- npm run start *(fails: TypeScript compilation errors complaining about missing bcrypt module and incompatible query return type in migrations)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f4d6db4c832ba4b72ec5071f9d0e