### PR TITLE
feat: enable authenticated profile and password updates

### DIFF
--- a/src/users/dto/update-user-password.dto.ts
+++ b/src/users/dto/update-user-password.dto.ts
@@ -1,0 +1,16 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString, MinLength } from "class-validator";
+
+export class UpdateUserPasswordDto {
+    @ApiProperty({ description: "Contraseña actual del usuario", example: "Actual123!" })
+    @IsString()
+    @IsNotEmpty()
+    currentPassword!: string;
+
+    @ApiProperty({ description: "Nueva contraseña a establecer", example: "NuevaContraseña456!" })
+    @IsString()
+    @MinLength(8)
+    newPassword!: string;
+}

--- a/src/users/dto/update-user-profile.dto.ts
+++ b/src/users/dto/update-user-profile.dto.ts
@@ -1,0 +1,36 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsOptional, IsString, Length, Matches } from "class-validator";
+
+export class UpdateUserProfileDto {
+    @ApiPropertyOptional({ description: "Nombre del usuario", example: "Juan" })
+    @IsOptional()
+    @IsString()
+    @Length(1, 80)
+    firstName?: string;
+
+    @ApiPropertyOptional({ description: "Apellido del usuario", example: "Pérez" })
+    @IsOptional()
+    @IsString()
+    @Length(1, 120)
+    lastName?: string;
+
+    @ApiPropertyOptional({ description: "Nombre de usuario único", example: "juan.perez" })
+    @IsOptional()
+    @IsString()
+    @Length(3, 40)
+    username?: string;
+
+    @ApiPropertyOptional({
+        description: "Teléfono de contacto del usuario",
+        example: "+34999888777",
+        nullable: true,
+    })
+    @IsOptional()
+    @IsString()
+    @Matches(/^[+\d][\d\s\-]{6,}$/u, {
+        message: "El teléfono debe contener al menos 7 dígitos y puede incluir el prefijo +",
+    })
+    phoneNumber?: string | null;
+}

--- a/src/users/user.controller.ts
+++ b/src/users/user.controller.ts
@@ -1,8 +1,12 @@
 /* eslint-disable prettier/prettier */
 
-import { Body, Controller, Post } from "@nestjs/common";
-import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { Body, Controller, Patch, Post, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOkResponse, ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
+import type { AuthenticatedRequest } from "src/common/interfaces/authenticated-request";
+import { JwtAuthGuard } from "src/common/guards/jwt-auth.guard";
 import { CreateUserDto } from "./dto/create-user.dto";
+import { UpdateUserPasswordDto } from "./dto/update-user-password.dto";
+import { UpdateUserProfileDto } from "./dto/update-user-profile.dto";
 import { User } from "./user.repository";
 import { UserService } from "./user.service";
 
@@ -16,5 +20,30 @@ export class UserController {
     @ApiResponse({ status: 500, description: "Error interno del servidor" })
     async registerUser(@Body() userDto: CreateUserDto): Promise<User> {
         return this.userService.registerUser(userDto);
+    }
+
+    @Patch("me")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Actualizar el perfil del usuario autenticado" })
+    @ApiOkResponse({ description: "Perfil actualizado correctamente" })
+    async updateProfile(
+        @Req() req: AuthenticatedRequest,
+        @Body() dto: UpdateUserProfileDto,
+    ): Promise<User> {
+        return this.userService.updateProfile(Number(req.user.userId), dto);
+    }
+
+    @Patch("me/password")
+    @UseGuards(JwtAuthGuard)
+    @ApiBearerAuth()
+    @ApiOperation({ summary: "Actualizar la contraseña del usuario autenticado" })
+    @ApiOkResponse({ description: "Contraseña actualizada correctamente" })
+    async updatePassword(
+        @Req() req: AuthenticatedRequest,
+        @Body() dto: UpdateUserPasswordDto,
+    ): Promise<{ message: string }> {
+        await this.userService.changePassword(Number(req.user.userId), dto);
+        return { message: "Contraseña actualizada correctamente" };
     }
 }


### PR DESCRIPTION
## Summary
- add authenticated PATCH /users/me and /users/me/password endpoints with Swagger documentation
- implement profile and password update flows with validation, hashing reuse, uniqueness handling, and persistence auditing
- introduce DTOs for profile and password updates to enforce payload constraints

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9fad838c8832b9fa31a9a9a606500