### PR TITLE
feat: add admin management module

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,95 @@
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiBearerAuth, ApiCreatedResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import { AdminRoleGuard } from 'src/common/guards/admin-role.guard';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { BlockUserDto } from './dto/block-user.dto';
+import { AuthenticatedRequest } from 'src/common/interfaces/authenticated-request';
+import { MetricsOverviewDto } from './dto/metrics-overview.dto';
+import { MetricsTopCategoryDto } from './dto/metrics-top-category.dto';
+import { MetricsTopHostDto } from './dto/metrics-top-host.dto';
+
+@ApiTags('Admin')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, AdminRoleGuard)
+@Controller('admin')
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('categories')
+  @ApiOperation({ summary: 'Listar categorías con sus contadores' })
+  @ApiOkResponse({ type: [CategoryResponseDto] })
+  async listCategories(): Promise<CategoryResponseDto[]> {
+    return this.adminService.listCategories();
+  }
+
+  @Post('categories')
+  @ApiOperation({ summary: 'Crear una nueva categoría' })
+  @ApiCreatedResponse({ type: CategoryResponseDto })
+  async createCategory(@Body() body: CreateCategoryDto): Promise<CategoryResponseDto> {
+    return this.adminService.createCategory(body);
+  }
+
+  @Put('categories/:id')
+  @ApiOperation({ summary: 'Actualizar una categoría existente' })
+  @ApiOkResponse({ type: CategoryResponseDto })
+  async updateCategory(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: UpdateCategoryDto,
+  ): Promise<CategoryResponseDto> {
+    return this.adminService.updateCategory(id, body);
+  }
+
+  @Post('users/:id/block')
+  @ApiOperation({ summary: 'Bloquear a un usuario' })
+  @ApiOkResponse({ description: 'Usuario bloqueado correctamente' })
+  async blockUser(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: BlockUserDto,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<void> {
+    const adminId = Number(req.user.userId);
+    await this.adminService.blockUser(id, adminId, body);
+  }
+
+  @Delete('users/:id/block')
+  @ApiOperation({ summary: 'Desbloquear a un usuario' })
+  @ApiOkResponse({ description: 'Usuario desbloqueado correctamente' })
+  async unblockUser(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<void> {
+    const adminId = Number(req.user.userId);
+    await this.adminService.unblockUser(id, adminId);
+  }
+
+  @Get('metrics/overview')
+  @ApiOperation({ summary: 'Obtener métricas generales del sistema' })
+  @ApiOkResponse({ type: MetricsOverviewDto })
+  async getMetricsOverview(): Promise<MetricsOverviewDto> {
+    return this.adminService.getMetricsOverview();
+  }
+
+  @Get('metrics/top-categories')
+  @ApiOperation({ summary: 'Obtener categorías con más actividad' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Número de categorías a devolver', type: Number, example: 5 })
+  @ApiOkResponse({ type: [MetricsTopCategoryDto] })
+  async getTopCategories(@Query('limit') limit?: string): Promise<MetricsTopCategoryDto[]> {
+    const parsed = Number(limit);
+    const sanitizedLimit = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 5;
+    return this.adminService.getTopCategories(sanitizedLimit);
+  }
+
+  @Get('metrics/top-hosts')
+  @ApiOperation({ summary: 'Obtener los hosts con más reportes registrados' })
+  @ApiQuery({ name: 'limit', required: false, description: 'Número de hosts a devolver', type: Number, example: 5 })
+  @ApiOkResponse({ type: [MetricsTopHostDto] })
+  async getTopHosts(@Query('limit') limit?: string): Promise<MetricsTopHostDto[]> {
+    const parsed = Number(limit);
+    const sanitizedLimit = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 5;
+    return this.adminService.getTopHosts(sanitizedLimit);
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+import { AdminRepository } from './admin.repository';
+import { DbModule } from 'src/db/db.module';
+import { AuthModule } from 'src/auth/auth.module';
+import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import { AdminRoleGuard } from 'src/common/guards/admin-role.guard';
+
+@Module({
+  imports: [DbModule, AuthModule],
+  controllers: [AdminController],
+  providers: [AdminService, AdminRepository, JwtAuthGuard, AdminRoleGuard],
+})
+export class AdminModule {}

--- a/src/admin/admin.repository.ts
+++ b/src/admin/admin.repository.ts
@@ -1,0 +1,248 @@
+import { Injectable } from '@nestjs/common';
+import { ResultSetHeader, RowDataPacket } from 'mysql2';
+import { DbService } from 'src/db/db.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+
+@Injectable()
+export class AdminRepository {
+  constructor(private readonly dbService: DbService) {}
+
+  async listCategories(): Promise<RowDataPacket[]> {
+    const sql = `
+      SELECT
+        id,
+        name,
+        slug,
+        description,
+        is_active,
+        reports_count,
+        search_count,
+        created_at,
+        updated_at
+      FROM categories
+      ORDER BY name ASC
+    `;
+
+    const [rows] = await this.dbService.getPool().query<RowDataPacket[]>(sql);
+    return rows;
+  }
+
+  async createCategory(payload: CreateCategoryDto): Promise<RowDataPacket | null> {
+    const sql = `
+      INSERT INTO categories (name, slug, description, is_active)
+      VALUES (?, ?, ?, ?)
+    `;
+
+    const params = [
+      payload.name,
+      payload.slug,
+      payload.description ?? null,
+      payload.is_active ?? true,
+    ];
+
+    const [result] = await this.dbService
+      .getPool()
+      .execute<ResultSetHeader>(sql, params);
+
+    return this.findCategoryById(result.insertId);
+  }
+
+  async updateCategory(id: number, payload: UpdateCategoryDto): Promise<RowDataPacket | null> {
+    const fields: string[] = [];
+    const params: Array<string | number | boolean | null> = [];
+
+    if (payload.name !== undefined) {
+      fields.push('name = ?');
+      params.push(payload.name);
+    }
+
+    if (payload.slug !== undefined) {
+      fields.push('slug = ?');
+      params.push(payload.slug);
+    }
+
+    if (payload.description !== undefined) {
+      fields.push('description = ?');
+      params.push(payload.description ?? null);
+    }
+
+    if (payload.is_active !== undefined) {
+      fields.push('is_active = ?');
+      params.push(payload.is_active);
+    }
+
+    if (payload.reports_count !== undefined) {
+      fields.push('reports_count = ?');
+      params.push(payload.reports_count);
+    }
+
+    if (payload.search_count !== undefined) {
+      fields.push('search_count = ?');
+      params.push(payload.search_count);
+    }
+
+    if (fields.length === 0) {
+      return this.findCategoryById(id);
+    }
+
+    fields.push('updated_at = CURRENT_TIMESTAMP');
+    const updateSql = `UPDATE categories SET ${fields.join(', ')} WHERE id = ?`;
+    params.push(id);
+
+    await this.dbService.getPool().execute<ResultSetHeader>(updateSql, params);
+
+    return this.findCategoryById(id);
+  }
+
+  async findCategoryById(id: number): Promise<RowDataPacket | null> {
+    const sql = `
+      SELECT
+        id,
+        name,
+        slug,
+        description,
+        is_active,
+        reports_count,
+        search_count,
+        created_at,
+        updated_at
+      FROM categories
+      WHERE id = ?
+      LIMIT 1
+    `;
+
+    const [rows] = await this.dbService
+      .getPool()
+      .execute<RowDataPacket[]>(sql, [id]);
+
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async blockUser(userId: number, adminId: number, reason?: string): Promise<boolean> {
+    const sql = `
+      UPDATE users
+      SET is_blocked = 1,
+          blocked_reason = ?,
+          blocked_by = ?,
+          blocked_at = CURRENT_TIMESTAMP,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `;
+
+    const [result] = await this.dbService
+      .getPool()
+      .execute<ResultSetHeader>(sql, [reason ?? null, adminId, userId]);
+
+    if (result.affectedRows === 0) {
+      return false;
+    }
+
+    await this.insertBlockEvent(userId, adminId, 'blocked', reason);
+    return true;
+  }
+
+  async unblockUser(userId: number, adminId: number): Promise<boolean> {
+    const sql = `
+      UPDATE users
+      SET is_blocked = 0,
+          blocked_reason = NULL,
+          blocked_by = ?,
+          blocked_at = NULL,
+          updated_at = CURRENT_TIMESTAMP
+      WHERE id = ?
+    `;
+
+    const [result] = await this.dbService.getPool().execute<ResultSetHeader>(sql, [adminId, userId]);
+
+    if (result.affectedRows === 0) {
+      return false;
+    }
+
+    await this.insertBlockEvent(userId, adminId, 'unblocked', null);
+    return true;
+  }
+
+  private async insertBlockEvent(
+    userId: number,
+    adminId: number,
+    action: 'blocked' | 'unblocked',
+    reason: string | null,
+  ): Promise<void> {
+    const sql = `
+      INSERT INTO user_block_events (user_id, action, reason, blocked_by_user_id)
+      VALUES (?, ?, ?, ?)
+    `;
+
+    await this.dbService.getPool().execute(sql, [userId, action, reason ?? null, adminId]);
+  }
+
+  async getMetricsOverview(): Promise<{ [key: string]: number }> {
+    const pool = this.dbService.getPool();
+
+    const [userCounts] = await pool.query<RowDataPacket[]>(
+      `
+      SELECT
+        COUNT(*) AS totalUsers,
+        COALESCE(SUM(is_blocked = 1), 0) AS blockedUsers
+      FROM users
+    `,
+    );
+
+    const [reportCounts] = await pool.query<RowDataPacket[]>(
+      `
+      SELECT
+        COUNT(*) AS totalReports,
+        COALESCE(SUM(status = 'approved'), 0) AS approvedReports,
+        COALESCE(SUM(status = 'pending'), 0) AS pendingReports
+      FROM reports
+    `,
+    );
+
+    const totals = { ...userCounts[0], ...reportCounts[0] } as unknown as {
+      totalUsers: number;
+      blockedUsers: number;
+      totalReports: number;
+      approvedReports: number;
+      pendingReports: number;
+    };
+
+    return totals;
+  }
+
+  async getTopCategories(limit: number): Promise<RowDataPacket[]> {
+    const sql = `
+      SELECT id, name, slug, reports_count AS reportsCount, search_count AS searchCount
+      FROM categories
+      ORDER BY reports_count DESC, search_count DESC
+      LIMIT ?
+    `;
+
+    const [rows] = await this.dbService
+      .getPool()
+      .execute<RowDataPacket[]>(sql, [limit]);
+
+    return rows;
+  }
+
+  async getTopHosts(limit: number): Promise<RowDataPacket[]> {
+    const sql = `
+      SELECT
+        rr.publisher_host AS host,
+        COUNT(*) AS reportsCount,
+        SUM(r.status = 'approved') AS approvedReportsCount
+      FROM reports r
+      INNER JOIN report_revisions rr ON rr.id = r.current_revision_id
+      WHERE rr.publisher_host IS NOT NULL AND rr.publisher_host <> ''
+      GROUP BY rr.publisher_host
+      ORDER BY reportsCount DESC, approvedReportsCount DESC
+      LIMIT ?
+    `;
+
+    const [rows] = await this.dbService
+      .getPool()
+      .execute<RowDataPacket[]>(sql, [limit]);
+
+    return rows;
+  }
+}

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { RowDataPacket } from 'mysql2';
+import { AdminRepository } from './admin.repository';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { CategoryResponseDto } from './dto/category-response.dto';
+import { BlockUserDto } from './dto/block-user.dto';
+import { MetricsOverviewDto } from './dto/metrics-overview.dto';
+import { MetricsTopCategoryDto } from './dto/metrics-top-category.dto';
+import { MetricsTopHostDto } from './dto/metrics-top-host.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(private readonly adminRepository: AdminRepository) {}
+
+  async listCategories(): Promise<CategoryResponseDto[]> {
+    const rows = await this.adminRepository.listCategories();
+    return rows.map((row) => this.mapCategory(row));
+  }
+
+  async createCategory(payload: CreateCategoryDto): Promise<CategoryResponseDto> {
+    const row = await this.adminRepository.createCategory(payload);
+    if (!row) {
+      throw new NotFoundException('No se pudo crear la categoría');
+    }
+
+    return this.mapCategory(row);
+  }
+
+  async updateCategory(id: number, payload: UpdateCategoryDto): Promise<CategoryResponseDto> {
+    const row = await this.adminRepository.updateCategory(id, payload);
+    if (!row) {
+      throw new NotFoundException('Categoría no encontrada');
+    }
+
+    return this.mapCategory(row);
+  }
+
+  async blockUser(userId: number, adminId: number, payload: BlockUserDto): Promise<void> {
+    const updated = await this.adminRepository.blockUser(userId, adminId, payload.reason);
+    if (!updated) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+  }
+
+  async unblockUser(userId: number, adminId: number): Promise<void> {
+    const updated = await this.adminRepository.unblockUser(userId, adminId);
+    if (!updated) {
+      throw new NotFoundException('Usuario no encontrado');
+    }
+  }
+
+  async getMetricsOverview(): Promise<MetricsOverviewDto> {
+    const totals = await this.adminRepository.getMetricsOverview();
+    return {
+      totalUsers: Number(totals.totalUsers ?? 0),
+      blockedUsers: Number(totals.blockedUsers ?? 0),
+      totalReports: Number(totals.totalReports ?? 0),
+      approvedReports: Number(totals.approvedReports ?? 0),
+      pendingReports: Number(totals.pendingReports ?? 0),
+    };
+  }
+
+  async getTopCategories(limit = 5): Promise<MetricsTopCategoryDto[]> {
+    const rows = await this.adminRepository.getTopCategories(limit);
+    return rows.map((row) => ({
+      id: Number(row.id),
+      name: String(row.name),
+      slug: String(row.slug),
+      reportsCount: Number(row.reportsCount ?? 0),
+      searchCount: Number(row.searchCount ?? 0),
+    }));
+  }
+
+  async getTopHosts(limit = 5): Promise<MetricsTopHostDto[]> {
+    const rows = await this.adminRepository.getTopHosts(limit);
+    return rows.map((row) => ({
+      host: String(row.host),
+      reportsCount: Number(row.reportsCount ?? 0),
+      approvedReportsCount: Number(row.approvedReportsCount ?? 0),
+    }));
+  }
+
+  private mapCategory(row: RowDataPacket): CategoryResponseDto {
+    return {
+      id: Number(row.id),
+      name: String(row.name),
+      slug: String(row.slug),
+      description: row.description ?? null,
+      is_active: Boolean(row.is_active),
+      reports_count: Number(row.reports_count ?? 0),
+      search_count: Number(row.search_count ?? 0),
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+      updated_at: row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at),
+    };
+  }
+}

--- a/src/admin/dto/block-user.dto.ts
+++ b/src/admin/dto/block-user.dto.ts
@@ -1,0 +1,10 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class BlockUserDto {
+  @ApiPropertyOptional({ description: 'Motivo del bloqueo aplicado por el administrador', example: 'Incumplimiento reiterado de las normas' })
+  @IsString()
+  @IsOptional()
+  @MaxLength(255)
+  reason?: string;
+}

--- a/src/admin/dto/category-response.dto.ts
+++ b/src/admin/dto/category-response.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CategoryResponseDto {
+  @ApiProperty({ description: 'Identificador de la categoría' })
+  id!: number;
+
+  @ApiProperty({ description: 'Nombre visible de la categoría' })
+  name!: string;
+
+  @ApiProperty({ description: 'Slug único para búsquedas' })
+  slug!: string;
+
+  @ApiProperty({ description: 'Descripción de la categoría', nullable: true })
+  description!: string | null;
+
+  @ApiProperty({ description: 'Indica si la categoría acepta nuevos reportes' })
+  is_active!: boolean;
+
+  @ApiProperty({ description: 'Cantidad de reportes asociados' })
+  reports_count!: number;
+
+  @ApiProperty({ description: 'Cantidad de búsquedas asociadas' })
+  search_count!: number;
+
+  @ApiProperty({ description: 'Fecha de creación', type: String })
+  created_at!: string;
+
+  @ApiProperty({ description: 'Fecha de última actualización', type: String })
+  updated_at!: string;
+}

--- a/src/admin/dto/create-category.dto.ts
+++ b/src/admin/dto/create-category.dto.ts
@@ -1,0 +1,26 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateCategoryDto {
+  @ApiProperty({ description: 'Nombre visible de la categoría', example: 'Fake News' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(120)
+  name!: string;
+
+  @ApiProperty({ description: 'Slug único para búsquedas', example: 'fake-news' })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(140)
+  slug!: string;
+
+  @ApiPropertyOptional({ description: 'Descripción de la categoría', example: 'Reportes relacionados a información falsa' })
+  @IsString()
+  @IsOptional()
+  description?: string | null;
+
+  @ApiPropertyOptional({ description: 'Si la categoría está activa para nuevos reportes', default: true })
+  @IsBoolean()
+  @IsOptional()
+  is_active?: boolean;
+}

--- a/src/admin/dto/metrics-overview.dto.ts
+++ b/src/admin/dto/metrics-overview.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MetricsOverviewDto {
+  @ApiProperty({ description: 'Total de usuarios registrados' })
+  totalUsers!: number;
+
+  @ApiProperty({ description: 'Usuarios con el estado bloqueado activo' })
+  blockedUsers!: number;
+
+  @ApiProperty({ description: 'Reportes totales registrados' })
+  totalReports!: number;
+
+  @ApiProperty({ description: 'Reportes aprobados publicados' })
+  approvedReports!: number;
+
+  @ApiProperty({ description: 'Reportes pendientes de revisión' })
+  pendingReports!: number;
+}

--- a/src/admin/dto/metrics-top-category.dto.ts
+++ b/src/admin/dto/metrics-top-category.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MetricsTopCategoryDto {
+  @ApiProperty({ description: 'Identificador de la categoría' })
+  id!: number;
+
+  @ApiProperty({ description: 'Nombre visible de la categoría' })
+  name!: string;
+
+  @ApiProperty({ description: 'Slug asociado a la categoría' })
+  slug!: string;
+
+  @ApiProperty({ description: 'Cantidad de reportes aprobados asociados a la categoría' })
+  reportsCount!: number;
+
+  @ApiProperty({ description: 'Cantidad de búsquedas registradas para la categoría' })
+  searchCount!: number;
+}

--- a/src/admin/dto/metrics-top-host.dto.ts
+++ b/src/admin/dto/metrics-top-host.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MetricsTopHostDto {
+  @ApiProperty({ description: 'Host del medio o sitio reportado' })
+  host!: string;
+
+  @ApiProperty({ description: 'Cantidad total de reportes asociados al host' })
+  reportsCount!: number;
+
+  @ApiProperty({ description: 'Cantidad de reportes aprobados para el host' })
+  approvedReportsCount!: number;
+}

--- a/src/admin/dto/update-category.dto.ts
+++ b/src/admin/dto/update-category.dto.ts
@@ -1,0 +1,18 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateCategoryDto } from './create-category.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsInt, IsOptional, Min } from 'class-validator';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {
+  @ApiPropertyOptional({ description: 'Cantidad acumulada de reportes aprobados asociados', minimum: 0 })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  reports_count?: number;
+
+  @ApiPropertyOptional({ description: 'Cantidad de búsquedas asociadas a la categoría', minimum: 0 })
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  search_count?: number;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,13 +10,14 @@ import { AuthModule } from './auth/auth.module';
 import { JwtModule } from '@nestjs/jwt';
 import { FilesModule } from './files/files.module';
 import { ReportsModule } from './reports/reports.module';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [JwtModule.register({
       global: true,
       secret:"supersecret"
   }), 
-  DbModule, UserModule, AuthModule, FilesModule, ReportsModule],
+  DbModule, UserModule, AuthModule, FilesModule, ReportsModule, AdminModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/common/guards/admin-role.guard.spec.ts
+++ b/src/common/guards/admin-role.guard.spec.ts
@@ -1,0 +1,32 @@
+import { ExecutionContext, ForbiddenException } from '@nestjs/common';
+import { AdminRoleGuard } from './admin-role.guard';
+
+const createContext = (user: unknown): ExecutionContext => ({
+  switchToHttp: () => ({
+    getRequest: () => ({ user }),
+  }),
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any);
+
+describe('AdminRoleGuard', () => {
+  let guard: AdminRoleGuard;
+
+  beforeEach(() => {
+    guard = new AdminRoleGuard();
+  });
+
+  it('permite el acceso cuando el usuario es admin', () => {
+    const context = createContext({ role: 'admin' });
+    expect(guard.canActivate(context)).toBe(true);
+  });
+
+  it('lanza ForbiddenException cuando el usuario no es admin', () => {
+    const context = createContext({ role: 'user' });
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+
+  it('lanza ForbiddenException cuando no hay usuario en la petición', () => {
+    const context = createContext(undefined);
+    expect(() => guard.canActivate(context)).toThrow(ForbiddenException);
+  });
+});

--- a/src/common/guards/admin-role.guard.ts
+++ b/src/common/guards/admin-role.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { AuthenticatedRequest } from '../interfaces/authenticated-request';
+
+@Injectable()
+export class AdminRoleGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const user = request.user;
+
+    if (!user || user.role !== 'admin') {
+      throw new ForbiddenException('Acceso restringido a administradores');
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add an admin module with guarded routes for managing categories, user blocks, and metrics
- implement repository logic to maintain category counters, block events, and aggregated analytics
- introduce an admin role guard with unit coverage to verify authorization behavior

## Testing
- npm test
- npx jest src/common/guards/admin-role.guard.spec.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da00db43b8832b85ebd5da2141b38f