### PR TITLE
feat: add my reports listing and pending-only soft delete

### DIFF
--- a/src/reports/dto/get-my-reports-query.dto.ts
+++ b/src/reports/dto/get-my-reports-query.dto.ts
@@ -1,0 +1,29 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, Min } from 'class-validator';
+import { ReportStatus } from '../report.repository';
+
+const REPORT_STATUS_VALUES: ReportStatus[] = ['pending', 'approved', 'rejected', 'removed'];
+
+export class GetMyReportsQueryDto {
+  @ApiPropertyOptional({ description: 'Número de página a recuperar', example: 1 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Cantidad de reportes por página', example: 10 })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number;
+
+  @ApiPropertyOptional({ description: 'Filtrar reportes por estado actual', enum: REPORT_STATUS_VALUES })
+  @IsOptional()
+  @IsEnum(REPORT_STATUS_VALUES)
+  status?: ReportStatus;
+}

--- a/src/reports/dto/get-my-reports-response.dto.ts
+++ b/src/reports/dto/get-my-reports-response.dto.ts
@@ -1,0 +1,51 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiProperty } from '@nestjs/swagger';
+import { ReportStatus } from '../report.repository';
+
+const REPORT_STATUS_VALUES: ReportStatus[] = ['pending', 'approved', 'rejected', 'removed'];
+
+export class MyReportListItemDto {
+  @ApiProperty({ description: 'Identificador del reporte' })
+  reportId: number;
+
+  @ApiProperty({ description: 'Título del reporte en su revisión actual', nullable: true })
+  title: string | null;
+
+  @ApiProperty({ description: 'Estado actual del reporte', enum: REPORT_STATUS_VALUES })
+  status: ReportStatus;
+
+  @ApiProperty({ description: 'Identificador de la categoría asociada' })
+  categoryId: number;
+
+  @ApiProperty({ description: 'Nombre de la categoría asociada', nullable: true })
+  categoryName: string | null;
+
+  @ApiProperty({ description: 'Fecha de creación del reporte', example: '2024-01-05T12:34:56.000Z' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Fecha de última edición realizada por el autor', nullable: true, example: '2024-01-06T08:15:00.000Z' })
+  lastEditedAt: string | null;
+
+  @ApiProperty({ description: 'Fecha de la última actualización del registro', example: '2024-01-06T08:15:00.000Z' })
+  updatedAt: string;
+}
+
+export class MyReportsMetaDto {
+  @ApiProperty({ description: 'Número de página solicitado', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: 'Cantidad de elementos por página', example: 10 })
+  limit: number;
+
+  @ApiProperty({ description: 'Total de reportes encontrados para el usuario', example: 25 })
+  total: number;
+}
+
+export class GetMyReportsResponseDto {
+  @ApiProperty({ type: [MyReportListItemDto] })
+  items: MyReportListItemDto[];
+
+  @ApiProperty({ type: MyReportsMetaDto })
+  meta: MyReportsMetaDto;
+}


### PR DESCRIPTION
## Summary
- add an authenticated `/reports/mine` endpoint with pagination and metadata for the author
- enable soft deletion for pending reports through a protected `DELETE /reports/:id`
- extend the report repository/service to filter by author and status for profile views

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da02ec447c832babf7e3c9453e045b