### PR TITLE
Enable global validation and harden DTO constraints

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,20 +1,29 @@
 /* eslint-disable prettier/prettier */
 
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { join } from 'path';
+import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
   app.useStaticAssets(join(__dirname, '..', 'public'), { prefix: '/public/' });
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
   const config = new DocumentBuilder()
-  .setTitle("API de Gestión de Usuarios")
-  .setDescription("API para gestionar usuarios con autenticación JWT")
-  .setVersion("1.0")
-  .build();
+    .setTitle('API de Gestión de Usuarios')
+    .setDescription('API para gestionar usuarios con autenticación JWT')
+    .setVersion('1.0')
+    .build();
   const doc = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup("docs", app, doc);
+  SwaggerModule.setup('docs', app, doc);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/users/dto/create-user.dto.ts
+++ b/src/users/dto/create-user.dto.ts
@@ -1,29 +1,57 @@
 /* eslint-disable prettier/prettier */
 
 import { ApiProperty } from "@nestjs/swagger";
-import { IsIn } from "class-validator";
+import {
+    IsEmail,
+    IsIn,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    Matches,
+    MinLength,
+} from "class-validator";
 import type { UserRole } from "../user.repository";
 
 export class CreateUserDto {
     @ApiProperty({ example: "user@example.com", description: "Email del usuario" })
-    email: string;
+    @IsEmail({}, { message: "El correo electrónico debe ser válido" })
+    email!: string;
 
     @ApiProperty({ example: "user123", description: "Nombre de usuario único" })
-    username: string;
+    @IsString()
+    @Matches(/^[a-zA-Z0-9._-]{3,30}$/u, {
+        message: "El nombre de usuario debe tener entre 3 y 30 caracteres y solo puede incluir letras, números, puntos, guiones y guiones bajos",
+    })
+    username!: string;
 
     @ApiProperty({ example: "Juan", description: "Nombre del usuario" })
-    firstName: string;
+    @IsString()
+    @IsNotEmpty()
+    firstName!: string;
 
     @ApiProperty({ example: "Pérez", description: "Apellido del usuario" })
-    lastName: string;
+    @IsString()
+    @IsNotEmpty()
+    lastName!: string;
 
     @ApiProperty({ example: "+34999888777", description: "Teléfono de contacto", required: false })
+    @IsOptional()
+    @IsString()
+    @Matches(/^[+\d][\d\s\-]{6,}$/u, {
+        message: "El teléfono debe contener al menos 7 dígitos y puede incluir espacios, guiones o el prefijo +",
+    })
     phoneNumber?: string;
 
     @ApiProperty({ example: "password123", description: "Contraseña del usuario" })
-    password: string;
+    @IsString()
+    @MinLength(8, { message: "La contraseña debe tener al menos 8 caracteres" })
+    @Matches(/^(?=.*[A-Za-z])(?=.*\d).+$/u, {
+        message: "La contraseña debe incluir al menos una letra y un número",
+    })
+    password!: string;
 
     @ApiProperty({ enum: ["user", "admin"], required: false, description: "Rol del usuario" })
+    @IsOptional()
     @IsIn(["user", "admin"])
     role?: UserRole;
 }

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,5 +1,5 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
@@ -13,6 +13,13 @@ describe('AppController (e2e)', () => {
     }).compile();
 
     app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: true,
+        transform: true,
+      }),
+    );
     await app.init();
   });
 

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -3,6 +3,12 @@
   "rootDir": ".",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
+  "moduleDirectories": ["node_modules", "<rootDir>/../node_modules"],
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/../src/$1",
+    "^bcrypt$": "<rootDir>/mocks/bcrypt.ts",
+    "^class-transformer$": "<rootDir>/../node_modules/class-transformer/cjs/index.js"
+  },
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"
   }


### PR DESCRIPTION
## Summary
- register the global validation pipe before setting up Swagger so incoming payloads are sanitized
- add comprehensive class-validator rules to the CreateUserDto covering email, username, names, phone number, password, and role
- align the e2e test harness with the runtime validation setup and configure Jest to resolve Nest-style module imports and mocks

## Testing
- npm run test
- npm run test:e2e *(fails: MySQL seeding via RejectionReasonRepository requires a database connection in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da0b3300b8832b95a0bac648840b6d