### PR TITLE
Handle unauthorized login for missing users

### DIFF
--- a/src/auth/auth.controller.spec.ts
+++ b/src/auth/auth.controller.spec.ts
@@ -1,4 +1,4 @@
-import { ForbiddenException } from "@nestjs/common";
+import { ForbiddenException, UnauthorizedException } from "@nestjs/common";
 import { AuthController } from "./auth.controller";
 import { TokenService } from "./tokens.service";
 import { UserService } from "src/users/user.service";
@@ -67,6 +67,17 @@ describe("AuthController", () => {
 
             await expect(controller.login({ email: "user@example.com", password: "Passw0rd" })).rejects.toBeInstanceOf(
                 ForbiddenException,
+            );
+
+            expect(tokenService.generateAccess).not.toHaveBeenCalled();
+            expect(tokenService.generateRefresh).not.toHaveBeenCalled();
+        });
+
+        it("should return unauthorized when the email does not exist", async () => {
+            userService.login.mockRejectedValue(new UnauthorizedException("Usuario no encontrado"));
+
+            await expect(controller.login({ email: "missing@example.com", password: "Passw0rd" })).rejects.toBeInstanceOf(
+                UnauthorizedException,
             );
 
             expect(tokenService.generateAccess).not.toHaveBeenCalled();

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -22,8 +22,6 @@ export class AuthController{
     @ApiOkResponse({ description: "Tokens generados correctamente", type: LoginResponseDto })
     async login(@Body() dto: LoginRequestDto): Promise<LoginResponseDto>{
         const usuario= await this.userService.login(dto.email, dto.password);
-        if(!usuario)
-            throw Error("Usuario no encontrado");
         const userName = `${usuario.first_name} ${usuario.last_name}`.trim() || usuario.username;
         const userProfile = {
             id: usuario.id.toString(),

--- a/src/users/user.service.spec.ts
+++ b/src/users/user.service.spec.ts
@@ -130,10 +130,12 @@ describe("UserService", () => {
             });
         });
 
-        it("should throw when user does not exist", async () => {
+        it("should throw unauthorized when user does not exist", async () => {
             userRepository.findByEmail.mockResolvedValue(null);
 
-            await expect(service.login(createUserDto.email, createUserDto.password)).rejects.toThrow("Usuario no encontrado");
+            await expect(service.login(createUserDto.email, createUserDto.password)).rejects.toBeInstanceOf(
+                UnauthorizedException,
+            );
         });
 
         it("should reject invalid passwords using bcrypt.compare", async () => {

--- a/src/users/user.service.ts
+++ b/src/users/user.service.ts
@@ -43,7 +43,9 @@ export class UserService {
 
     async login(email: string, password: string): Promise<User> {
         const user = await this.userRepository.findByEmail(email);
-        if (!user) throw Error("Usuario no encontrado");
+        if (!user) {
+            throw new UnauthorizedException("Usuario no encontrado");
+        }
 
         if (this.isUserBlocked(user)) {
             await this.recordBlockedLoginAttempt(user);


### PR DESCRIPTION
## Summary
- replace the generic error thrown when a user is missing with an UnauthorizedException in the login service
- rely on the service to surface login errors directly from the controller
- cover the 401 scenario for missing emails in both service and controller unit tests

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68da0cf3e160832ba5640359817073ca