### PR TITLE
feat: add admin report moderation endpoints

### DIFF
--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -11,6 +11,8 @@ import type { AuthenticatedRequest } from 'src/common/interfaces/authenticated-r
 import { MetricsOverviewDto } from './dto/metrics-overview.dto';
 import { MetricsTopCategoryDto } from './dto/metrics-top-category.dto';
 import { MetricsTopHostDto } from './dto/metrics-top-host.dto';
+import { GetAdminReportsQueryDto } from './dto/get-admin-reports-query.dto';
+import { GetAdminReportsResponseDto } from './dto/get-admin-reports-response.dto';
 
 @ApiTags('Admin')
 @ApiBearerAuth()
@@ -18,6 +20,13 @@ import { MetricsTopHostDto } from './dto/metrics-top-host.dto';
 @Controller('admin')
 export class AdminController {
   constructor(private readonly adminService: AdminService) {}
+
+  @Get('reports')
+  @ApiOperation({ summary: 'Listar reportes para la consola de moderación' })
+  @ApiOkResponse({ type: GetAdminReportsResponseDto })
+  async listReports(@Query() query: GetAdminReportsQueryDto): Promise<GetAdminReportsResponseDto> {
+    return this.adminService.listReports(query);
+  }
 
   @Get('categories')
   @ApiOperation({ summary: 'Listar categorías con sus contadores' })
@@ -64,6 +73,18 @@ export class AdminController {
   ): Promise<void> {
     const adminId = Number(req.user.userId);
     await this.adminService.unblockUser(id, adminId);
+  }
+
+  @Delete('reports/:id')
+  @ApiOperation({ summary: 'Eliminar un reporte desde la consola de administración' })
+  @ApiOkResponse({ description: 'Reporte eliminado correctamente' })
+  async removeReport(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: AuthenticatedRequest,
+  ): Promise<{ success: true }> {
+    const adminId = Number(req.user.userId);
+    await this.adminService.removeReport(id, adminId);
+    return { success: true };
   }
 
   @Get('metrics/overview')

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -6,10 +6,11 @@ import { DbModule } from 'src/db/db.module';
 import { AuthModule } from 'src/auth/auth.module';
 import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
 import { AdminRoleGuard } from 'src/common/guards/admin-role.guard';
+import { ReportRepository } from 'src/reports/report.repository';
 
 @Module({
   imports: [DbModule, AuthModule],
   controllers: [AdminController],
-  providers: [AdminService, AdminRepository, JwtAuthGuard, AdminRoleGuard],
+  providers: [AdminService, AdminRepository, ReportRepository, JwtAuthGuard, AdminRoleGuard],
 })
 export class AdminModule {}

--- a/src/admin/dto/get-admin-reports-query.dto.ts
+++ b/src/admin/dto/get-admin-reports-query.dto.ts
@@ -1,0 +1,32 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, Max, Min } from 'class-validator';
+import type { ReportStatus } from 'src/reports/report.repository';
+
+const REPORT_STATUS_VALUES: ReportStatus[] = ['pending', 'approved', 'rejected', 'removed'];
+
+export class GetAdminReportsQueryDto {
+  @ApiPropertyOptional({
+    description: 'Filtrar los reportes por estado actual',
+    enum: REPORT_STATUS_VALUES,
+    example: 'pending',
+  })
+  @IsOptional()
+  @IsIn(REPORT_STATUS_VALUES)
+  status?: ReportStatus;
+
+  @ApiPropertyOptional({ description: 'Número de página para la paginación', minimum: 1, example: 1, default: 1 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  page = 1;
+
+  @ApiPropertyOptional({ description: 'Cantidad de elementos por página', minimum: 1, maximum: 100, example: 20, default: 20 })
+  @Type(() => Number)
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit = 20;
+}

--- a/src/admin/dto/get-admin-reports-response.dto.ts
+++ b/src/admin/dto/get-admin-reports-response.dto.ts
@@ -1,0 +1,83 @@
+import { ApiProperty } from '@nestjs/swagger';
+import type { ReportStatus } from 'src/reports/report.repository';
+
+const REPORT_STATUS_VALUES: ReportStatus[] = ['pending', 'approved', 'rejected', 'removed'];
+
+export class AdminReportAuthorDto {
+  @ApiProperty({ description: 'Identificador del autor del reporte', example: 42 })
+  id: number;
+
+  @ApiProperty({ description: 'Correo electrónico del autor', example: 'autor@ofraud.test' })
+  email: string | null;
+
+  @ApiProperty({ description: 'Nombre completo del autor', example: 'María Pérez' })
+  name: string | null;
+}
+
+export class AdminReportReviewerDto {
+  @ApiProperty({ description: 'Identificador del administrador que revisó el reporte', example: 7 })
+  id: number;
+
+  @ApiProperty({ description: 'Nombre completo del administrador', example: 'Equipo Moderación' })
+  name: string | null;
+}
+
+export class AdminReportListItemDto {
+  @ApiProperty({ description: 'Identificador del reporte', example: 101 })
+  reportId: number;
+
+  @ApiProperty({ description: 'Título de la revisión aprobada o pendiente', nullable: true })
+  title: string | null;
+
+  @ApiProperty({ description: 'Estado actual del reporte', enum: REPORT_STATUS_VALUES })
+  status: ReportStatus;
+
+  @ApiProperty({ description: 'Identificador de la categoría asociada', example: 3 })
+  categoryId: number;
+
+  @ApiProperty({ description: 'Nombre de la categoría asociada', example: 'Noticias falsas', nullable: true })
+  categoryName: string | null;
+
+  @ApiProperty({ type: AdminReportAuthorDto })
+  author: AdminReportAuthorDto;
+
+  @ApiProperty({ type: AdminReportReviewerDto, nullable: true })
+  reviewer: AdminReportReviewerDto | null;
+
+  @ApiProperty({ description: 'Fecha de creación del reporte en formato ISO 8601' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Fecha de última actualización del reporte en formato ISO 8601' })
+  updatedAt: string;
+
+  @ApiProperty({ description: 'Fecha en la que se revisó el reporte', nullable: true })
+  reviewedAt: string | null;
+
+  @ApiProperty({ description: 'Fecha de publicación del reporte', nullable: true })
+  publishedAt: string | null;
+
+  @ApiProperty({ description: 'Notas de revisión registradas por el administrador', nullable: true })
+  reviewNotes: string | null;
+
+  @ApiProperty({ description: 'Motivo de rechazo o eliminación, cuando aplica', nullable: true })
+  rejectionReasonText: string | null;
+}
+
+export class AdminReportsMetaDto {
+  @ApiProperty({ description: 'Número de página devuelto', example: 1 })
+  page: number;
+
+  @ApiProperty({ description: 'Cantidad de elementos por página', example: 20 })
+  limit: number;
+
+  @ApiProperty({ description: 'Cantidad total de reportes que cumplen el filtro', example: 57 })
+  total: number;
+}
+
+export class GetAdminReportsResponseDto {
+  @ApiProperty({ type: [AdminReportListItemDto] })
+  items: AdminReportListItemDto[];
+
+  @ApiProperty({ type: AdminReportsMetaDto })
+  meta: AdminReportsMetaDto;
+}

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,16 +1,317 @@
 import { INestApplication, ValidationPipe } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
-import * as request from 'supertest';
+import request from 'supertest';
 import { App } from 'supertest/types';
 import { AppModule } from './../src/app.module';
+import { DbService } from 'src/db/db.service';
+import { ReportRepository, ReportStatus, type ReportRecord } from 'src/reports/report.repository';
+import { RejectionReasonRepository } from 'src/reports/rejection-reason.repository';
+import { TokenService } from 'src/auth/tokens.service';
 
-describe('AppController (e2e)', () => {
+interface MockUser {
+  id: number;
+  email: string;
+  firstName: string;
+  lastName: string;
+  role: 'user' | 'admin';
+}
+
+interface MockReport {
+  id: number;
+  status: ReportStatus;
+  authorId: number;
+  categoryId: number;
+  currentRevisionId: number | null;
+  reviewedBy: number | null;
+  reviewedAt: Date | null;
+  publishedAt: Date | null;
+  reviewNotes: string | null;
+  rejectionReasonText: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+}
+
+interface MockRevision {
+  id: number;
+  reportId: number;
+  title: string | null;
+}
+
+interface MockCategory {
+  id: number;
+  name: string;
+}
+
+interface MockState {
+  users: Map<number, MockUser>;
+  reports: Map<number, MockReport>;
+  revisions: Map<number, MockRevision>;
+  categories: Map<number, MockCategory>;
+  history: Array<{ reportId: number; toStatus: ReportStatus }>;
+}
+
+const buildMockReportRepository = (state: MockState): ReportRepository => {
+  const withTransaction = jest.fn(async <T>(handler: (conn: unknown) => Promise<T>): Promise<T> => {
+    return handler({} as unknown);
+  });
+
+  const findReportForUpdate = jest.fn(async (reportId: number) => {
+    const report = state.reports.get(reportId);
+    if (!report) {
+      return undefined;
+    }
+
+    const record: ReportRecord = {
+      id: report.id,
+      author_id: report.authorId,
+      category_id: report.categoryId,
+      current_revision_id: report.currentRevisionId,
+      status: report.status,
+      reviewed_by: report.reviewedBy,
+      reviewed_at: report.reviewedAt,
+      approved_at: report.publishedAt,
+      review_notes: report.reviewNotes,
+      rejection_reason_id: null,
+      rejection_reason_text: report.rejectionReasonText,
+      is_locked: 0,
+      is_anonymous: 0,
+      rating_average: '0',
+      rating_count: 0,
+      published_at: report.publishedAt,
+      deleted_at: report.deletedAt,
+      created_at: report.createdAt,
+      updated_at: report.updatedAt,
+    };
+
+    return record;
+  });
+
+  const updateReportStatus = jest.fn(
+    async (
+      _conn: unknown,
+      payload: {
+        reportId: number;
+        status: ReportStatus;
+        reviewerId: number;
+        reviewNotes?: string | null;
+        rejectionReasonId?: number | null;
+        rejectionReasonText?: string | null;
+        lock?: boolean;
+        approvedAt?: Date | null;
+        publishedAt?: Date | null;
+      },
+    ) => {
+      const report = state.reports.get(payload.reportId);
+      if (!report) {
+        throw new Error('Report not found');
+      }
+
+      const now = new Date();
+      report.status = payload.status;
+      report.reviewedBy = payload.reviewerId;
+      report.reviewedAt = now;
+      report.reviewNotes = payload.reviewNotes ?? null;
+      report.rejectionReasonText = payload.rejectionReasonText ?? null;
+      report.publishedAt = payload.publishedAt ?? null;
+      report.updatedAt = now;
+    },
+  );
+
+  const updateReportCurrentRevision = jest.fn(async (_conn: unknown, reportId: number, revisionId: number) => {
+    const report = state.reports.get(reportId);
+    if (!report) {
+      throw new Error('Report not found');
+    }
+
+    report.currentRevisionId = revisionId;
+  });
+
+  const appendStatusHistory = jest.fn(
+    async (
+      _conn: unknown,
+      payload: {
+        reportId: number;
+        toStatus: ReportStatus;
+      },
+    ) => {
+      state.history.push({ reportId: payload.reportId, toStatus: payload.toStatus });
+    },
+  );
+
+  const softDeleteReport = jest.fn(async (_conn: unknown, reportId: number) => {
+    const report = state.reports.get(reportId);
+    if (!report) {
+      throw new Error('Report not found');
+    }
+
+    const now = new Date();
+    report.status = 'removed';
+    report.deletedAt = now;
+    report.updatedAt = now;
+  });
+
+  const findReportsForAdmin = jest.fn(async (params: { status?: ReportStatus; limit: number; offset: number }) => {
+    const { status, limit, offset } = params;
+    let reports = Array.from(state.reports.values());
+
+    reports = reports.filter((report) => {
+      if (status && report.status !== status) {
+        return false;
+      }
+      if (status !== 'removed' && report.deletedAt) {
+        return false;
+      }
+      return true;
+    });
+
+    reports.sort((a, b) => {
+      const diff = b.updatedAt.getTime() - a.updatedAt.getTime();
+      return diff !== 0 ? diff : b.id - a.id;
+    });
+
+    const total = reports.length;
+    const slice = reports.slice(offset, offset + limit);
+
+    const items = slice.map((report) => {
+      const revision = report.currentRevisionId ? state.revisions.get(report.currentRevisionId) : undefined;
+      const author = state.users.get(report.authorId);
+      const reviewer = report.reviewedBy ? state.users.get(report.reviewedBy) : undefined;
+      const category = state.categories.get(report.categoryId);
+
+      return {
+        reportId: report.id,
+        title: revision?.title ?? null,
+        status: report.status,
+        categoryId: report.categoryId,
+        categoryName: category?.name ?? null,
+        authorId: report.authorId,
+        authorEmail: author?.email ?? null,
+        authorName: author ? `${author.firstName} ${author.lastName}`.trim() : null,
+        reviewerId: reviewer?.id ?? null,
+        reviewerName: reviewer ? `${reviewer.firstName} ${reviewer.lastName}`.trim() : null,
+        createdAt: report.createdAt,
+        updatedAt: report.updatedAt,
+        reviewedAt: report.reviewedAt,
+        publishedAt: report.publishedAt,
+        reviewNotes: report.reviewNotes,
+        rejectionReasonText: report.rejectionReasonText,
+      } as any;
+    });
+
+    return { items, total };
+  });
+
+  return {
+    withTransaction,
+    findReportForUpdate,
+    updateReportStatus,
+    updateReportCurrentRevision,
+    appendStatusHistory,
+    softDeleteReport,
+    findReportsForAdmin,
+  } as unknown as ReportRepository;
+};
+
+const rejectionReasonRepositoryMock: Partial<RejectionReasonRepository> = {
+  findById: jest.fn(async (id: number) => {
+    if (id === 1) {
+      return { id: 1, code: 'spam', label: 'Contenido promocional no deseado' } as any;
+    }
+    return undefined;
+  }),
+  findByCode: jest.fn(async (code: string) => {
+    if (code === 'spam') {
+      return { id: 1, code: 'spam', label: 'Contenido promocional no deseado' } as any;
+    }
+    return undefined;
+  }),
+  ensureSeeded: jest.fn(async () => undefined),
+};
+
+describe('Admin moderation console (e2e)', () => {
   let app: INestApplication<App>;
+  let tokenService: TokenService;
+  let state: MockState;
 
   beforeEach(async () => {
+    jest.clearAllMocks();
+
+    state = {
+      users: new Map<number, MockUser>([
+        [1, { id: 1, email: 'admin@ofraud.test', firstName: 'Admin', lastName: 'Root', role: 'admin' }],
+        [2, { id: 2, email: 'user@ofraud.test', firstName: 'Laura', lastName: 'Ríos', role: 'user' }],
+        [3, { id: 3, email: 'author@ofraud.test', firstName: 'Carlos', lastName: 'Mena', role: 'user' }],
+      ]),
+      reports: new Map<number, MockReport>([
+        [10, {
+          id: 10,
+          status: 'pending',
+          authorId: 2,
+          categoryId: 5,
+          currentRevisionId: 1001,
+          reviewedBy: null,
+          reviewedAt: null,
+          publishedAt: null,
+          reviewNotes: null,
+          rejectionReasonText: null,
+          createdAt: new Date('2024-01-01T10:00:00Z'),
+          updatedAt: new Date('2024-01-01T10:00:00Z'),
+          deletedAt: null,
+        }],
+        [11, {
+          id: 11,
+          status: 'approved',
+          authorId: 3,
+          categoryId: 6,
+          currentRevisionId: 1002,
+          reviewedBy: 1,
+          reviewedAt: new Date('2024-01-02T12:00:00Z'),
+          publishedAt: new Date('2024-01-02T12:00:00Z'),
+          reviewNotes: 'Aprobado originalmente',
+          rejectionReasonText: null,
+          createdAt: new Date('2024-01-01T08:00:00Z'),
+          updatedAt: new Date('2024-01-02T12:00:00Z'),
+          deletedAt: null,
+        }],
+        [12, {
+          id: 12,
+          status: 'pending',
+          authorId: 3,
+          categoryId: 6,
+          currentRevisionId: 1003,
+          reviewedBy: null,
+          reviewedAt: null,
+          publishedAt: null,
+          reviewNotes: null,
+          rejectionReasonText: null,
+          createdAt: new Date('2024-01-03T09:00:00Z'),
+          updatedAt: new Date('2024-01-03T09:00:00Z'),
+          deletedAt: null,
+        }],
+      ]),
+      revisions: new Map<number, MockRevision>([
+        [1001, { id: 1001, reportId: 10, title: 'Campaña sospechosa en redes' }],
+        [1002, { id: 1002, reportId: 11, title: 'Portal falso de banca' }],
+        [1003, { id: 1003, reportId: 12, title: 'Venta engañosa por email' }],
+      ]),
+      categories: new Map<number, MockCategory>([
+        [5, { id: 5, name: 'Estafas digitales' }],
+        [6, { id: 6, name: 'Phishing' }],
+      ]),
+      history: [],
+    };
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
-    }).compile();
+    })
+      .overrideProvider(DbService)
+      .useValue({ getPool: () => ({}) })
+      .overrideProvider(ReportRepository)
+      .useValue(buildMockReportRepository(state))
+      .overrideProvider(RejectionReasonRepository)
+      .useValue(rejectionReasonRepositoryMock)
+      .compile();
 
     app = moduleFixture.createNestApplication();
     app.useGlobalPipes(
@@ -20,13 +321,108 @@ describe('AppController (e2e)', () => {
         transform: true,
       }),
     );
+
     await app.init();
+    tokenService = moduleFixture.get(TokenService);
   });
 
-  it('/ (GET)', () => {
-    return request(app.getHttpServer())
-      .get('/')
+  afterEach(async () => {
+    await app.close();
+  });
+
+  const getAdminToken = async () => {
+    return tokenService.generateAccess({
+      id: '1',
+      email: 'admin@ofraud.test',
+      name: 'Admin Root',
+      role: 'admin',
+    });
+  };
+
+  it('GET /admin/reports devuelve los reportes paginados filtrados por estado', async () => {
+    const adminToken = await getAdminToken();
+
+    const response = await request(app.getHttpServer())
+      .get('/admin/reports')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .query({ status: 'pending', limit: 10, page: 1 })
+      .expect(200);
+
+    expect(response.body.meta).toEqual({ page: 1, limit: 10, total: 2 });
+    expect(response.body.items).toHaveLength(2);
+    expect(response.body.items[0]).toMatchObject({
+      reportId: 12,
+      status: 'pending',
+      categoryName: 'Phishing',
+    });
+  });
+
+  it('POST /reports/moderate permite aprobar un reporte pendiente', async () => {
+    const adminToken = await getAdminToken();
+
+    await request(app.getHttpServer())
+      .post('/reports/moderate')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        action: 'approve',
+        reportId: 10,
+        revisionId: 1001,
+        note: 'Contenido verificado',
+      })
+      .expect(201)
+      .expect({ success: true });
+
+    const report = state.reports.get(10)!;
+    expect(report.status).toBe('approved');
+    expect(report.reviewedBy).toBe(1);
+    expect(report.reviewNotes).toBe('Contenido verificado');
+    expect(state.history.some((entry) => entry.reportId === 10 && entry.toStatus === 'approved')).toBe(true);
+  });
+
+  it('POST /reports/moderate permite rechazar un reporte con un motivo', async () => {
+    const adminToken = await getAdminToken();
+
+    await request(app.getHttpServer())
+      .post('/reports/moderate')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        action: 'reject',
+        reportId: 12,
+        revisionId: 1003,
+        rejectionReasonId: 1,
+        note: 'Información insuficiente',
+      })
+      .expect(201)
+      .expect({ success: true });
+
+    const report = state.reports.get(12)!;
+    expect(report.status).toBe('rejected');
+    expect(report.reviewedBy).toBe(1);
+    expect(report.rejectionReasonText).toBe('Contenido promocional no deseado');
+    expect(state.history.some((entry) => entry.reportId === 12 && entry.toStatus === 'rejected')).toBe(true);
+  });
+
+  it('DELETE /admin/reports/:id marca el reporte como eliminado', async () => {
+    const adminToken = await getAdminToken();
+
+    await request(app.getHttpServer())
+      .delete('/admin/reports/11')
+      .set('Authorization', `Bearer ${adminToken}`)
       .expect(200)
-      .expect('Hello World!');
+      .expect({ success: true });
+
+    const report = state.reports.get(11)!;
+    expect(report.status).toBe('removed');
+    expect(report.deletedAt).not.toBeNull();
+    expect(state.history.some((entry) => entry.reportId === 11 && entry.toStatus === 'removed')).toBe(true);
+
+    const adminListing = await request(app.getHttpServer())
+      .get('/admin/reports')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .query({ status: 'removed' })
+      .expect(200);
+
+    expect(adminListing.body.meta.total).toBe(1);
+    expect(adminListing.body.items[0].reportId).toBe(11);
   });
 });

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -7,7 +7,8 @@
   "moduleNameMapper": {
     "^src/(.*)$": "<rootDir>/../src/$1",
     "^bcrypt$": "<rootDir>/mocks/bcrypt.ts",
-    "^class-transformer$": "<rootDir>/../node_modules/class-transformer/cjs/index.js"
+    "^class-transformer$": "<rootDir>/mocks/class-transformer.ts",
+    "^class-transformer/(.*)$": "<rootDir>/mocks/class-transformer.ts"
   },
   "transform": {
     "^.+\\.(t|j)s$": "ts-jest"

--- a/test/mocks/class-transformer.ts
+++ b/test/mocks/class-transformer.ts
@@ -1,0 +1,58 @@
+export type ClassConstructor<T> = new (...args: any[]) => T;
+
+const createMetadataMap = () => new Map<any, Map<any, any>>();
+
+export const defaultMetadataStorage = {
+  _excludeMetadatas: createMetadataMap(),
+  _exposeMetadatas: createMetadataMap(),
+  _transformMetadatas: createMetadataMap(),
+  _typeMetadatas: createMetadataMap(),
+};
+
+export function plainToInstance<T, V>(cls: ClassConstructor<T>, plain: V, _options?: unknown): T {
+  if (!cls || typeof cls !== 'function') {
+    return plain as unknown as T;
+  }
+
+  const instance = new cls();
+  const source = plain as Record<string, unknown>;
+
+  Object.keys(source).forEach((key) => {
+    const value = source[key];
+    const current = (instance as Record<string, unknown>)[key];
+
+    if (typeof current === 'number' && typeof value === 'string') {
+      const parsed = Number(value);
+      (instance as Record<string, unknown>)[key] = Number.isNaN(parsed) ? current : parsed;
+      return;
+    }
+
+    (instance as Record<string, unknown>)[key] = value;
+  });
+
+  return instance;
+}
+
+export const plainToClass = plainToInstance;
+
+export function instanceToPlain<T>(_instance: T, _options?: unknown): T {
+  return _instance;
+}
+
+export const classToPlain = instanceToPlain;
+
+export function Expose(): PropertyDecorator {
+  return () => undefined;
+}
+
+export function Exclude(): PropertyDecorator {
+  return () => undefined;
+}
+
+export function Transform(): PropertyDecorator {
+  return () => undefined;
+}
+
+export function Type(): PropertyDecorator {
+  return () => undefined;
+}


### PR DESCRIPTION
## Summary
- add admin report listing with filtering, pagination and swagger models
- allow administrators to soft-delete reports while tracking history
- extend e2e coverage with mocked repositories and adjust test configuration for class-transformer stubs

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_68da10a9513c832ba46e3f6cea82bb8d