### PR TITLE
Add public categories listing endpoint

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,13 +12,14 @@ import { JwtModule } from '@nestjs/jwt';
 import { FilesModule } from './files/files.module';
 import { ReportsModule } from './reports/reports.module';
 import { AdminModule } from './admin/admin.module';
+import { CategoriesModule } from './categories/categories.module';
 
 @Module({
   imports: [ConfigModule.forRoot({ isGlobal: true }), JwtModule.register({
       global: true,
       secret:"supersecret"
   }), 
-  DbModule, UserModule, AuthModule, FilesModule, ReportsModule, AdminModule],
+  DbModule, UserModule, AuthModule, FilesModule, ReportsModule, AdminModule, CategoriesModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { CategoryResponseDto } from 'src/admin/dto/category-response.dto';
+import { CategoriesService } from './categories.service';
+
+@ApiTags('Categories')
+@Controller('categories')
+export class CategoriesController {
+  constructor(private readonly categoriesService: CategoriesService) {}
+
+  @Get()
+  @ApiOperation({ summary: 'Listar categorías públicas disponibles' })
+  @ApiOkResponse({ type: [CategoryResponseDto] })
+  async listCategories(): Promise<CategoryResponseDto[]> {
+    return this.categoriesService.listCategories();
+  }
+}

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { DbModule } from 'src/db/db.module';
+import { AdminRepository } from 'src/admin/admin.repository';
+import { CategoriesController } from './categories.controller';
+import { CategoriesService } from './categories.service';
+
+@Module({
+  imports: [DbModule],
+  controllers: [CategoriesController],
+  providers: [CategoriesService, AdminRepository],
+})
+export class CategoriesModule {}

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -1,0 +1,88 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminRepository } from 'src/admin/admin.repository';
+import { CategoriesService } from './categories.service';
+
+const buildRow = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 1,
+  name: 'Fraude bancario',
+  slug: 'fraude-bancario',
+  description: 'Reportes relacionados a bancos',
+  is_active: 1,
+  reports_count: 42,
+  search_count: 7,
+  created_at: new Date('2024-01-01T00:00:00.000Z'),
+  updated_at: new Date('2024-02-01T00:00:00.000Z'),
+  ...overrides,
+});
+
+describe('CategoriesService', () => {
+  let service: CategoriesService;
+  let repository: AdminRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CategoriesService,
+        {
+          provide: AdminRepository,
+          useValue: {
+            listCategories: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get(CategoriesService);
+    repository = module.get(AdminRepository);
+  });
+
+  it('debería devolver categorías mapeadas correctamente', async () => {
+    const mockRow = buildRow();
+    jest.spyOn(repository, 'listCategories').mockResolvedValue([mockRow as any]);
+
+    const result = await service.listCategories();
+
+    expect(repository.listCategories).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: 'Fraude bancario',
+        slug: 'fraude-bancario',
+        description: 'Reportes relacionados a bancos',
+        is_active: true,
+        reports_count: 42,
+        search_count: 7,
+        created_at: '2024-01-01T00:00:00.000Z',
+        updated_at: '2024-02-01T00:00:00.000Z',
+      },
+    ]);
+  });
+
+  it('debería normalizar valores nulos', async () => {
+    const mockRow = buildRow({
+      description: null,
+      is_active: 0,
+      reports_count: null,
+      search_count: undefined,
+      created_at: '2024-01-01 00:00:00',
+      updated_at: '2024-02-01 00:00:00',
+    });
+    jest.spyOn(repository, 'listCategories').mockResolvedValue([mockRow as any]);
+
+    const result = await service.listCategories();
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        name: 'Fraude bancario',
+        slug: 'fraude-bancario',
+        description: null,
+        is_active: false,
+        reports_count: 0,
+        search_count: 0,
+        created_at: '2024-01-01 00:00:00',
+        updated_at: '2024-02-01 00:00:00',
+      },
+    ]);
+  });
+});

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@nestjs/common';
+import { RowDataPacket } from 'mysql2';
+import { AdminRepository } from 'src/admin/admin.repository';
+import { CategoryResponseDto } from 'src/admin/dto/category-response.dto';
+
+@Injectable()
+export class CategoriesService {
+  constructor(private readonly adminRepository: AdminRepository) {}
+
+  async listCategories(): Promise<CategoryResponseDto[]> {
+    const rows = await this.adminRepository.listCategories();
+    return rows.map((row) => this.mapCategory(row));
+  }
+
+  private mapCategory(row: RowDataPacket): CategoryResponseDto {
+    return {
+      id: Number(row.id),
+      name: String(row.name),
+      slug: String(row.slug),
+      description: row.description ?? null,
+      is_active: Boolean(row.is_active),
+      reports_count: Number(row.reports_count ?? 0),
+      search_count: Number(row.search_count ?? 0),
+      created_at:
+        row.created_at instanceof Date
+          ? row.created_at.toISOString()
+          : String(row.created_at),
+      updated_at:
+        row.updated_at instanceof Date
+          ? row.updated_at.toISOString()
+          : String(row.updated_at),
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a lightweight CategoriesModule with a public controller that exposes GET /categories and reuses the admin DTO
- wire the module into the application and document the new route in Swagger
- cover the mapping logic with unit tests for the new service

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68dc8c81a61c832b88dfbceec38e9d40