### PR TITLE
feat(reports): expose approved report detail endpoint

### DIFF
--- a/src/reports/dto/report-detail.dto.ts
+++ b/src/reports/dto/report-detail.dto.ts
@@ -1,0 +1,80 @@
+/* eslint-disable prettier/prettier */
+
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReportDetailCategoryDto {
+  @ApiProperty({ description: 'Identificador de la categoría asociada al reporte' })
+  id: number;
+
+  @ApiProperty({ description: 'Nombre visible de la categoría', nullable: true })
+  name: string | null;
+
+  @ApiProperty({ description: 'Slug público de la categoría', nullable: true })
+  slug: string | null;
+}
+
+export class ReportDetailAuthorDto {
+  @ApiProperty({ description: 'Indica si el reporte fue publicado en modo anónimo' })
+  isAnonymous: boolean;
+
+  @ApiProperty({ description: 'Identificador del autor cuando no es anónimo', nullable: true })
+  authorId: number | null;
+
+  @ApiProperty({ description: 'Nombre a mostrar del autor si está disponible', nullable: true })
+  displayName: string | null;
+}
+
+export class ReportDetailMediaDto {
+  @ApiProperty({ description: 'Identificador del archivo asociado a la revisión' })
+  mediaId: number;
+
+  @ApiProperty({ description: 'URL pública del recurso' })
+  fileUrl: string;
+
+  @ApiProperty({ description: 'Tipo de archivo almacenado', nullable: true })
+  mediaType: string | null;
+
+  @ApiProperty({ description: 'Posición relativa del recurso en la galería', example: 1 })
+  position: number;
+}
+
+export class ReportDetailDto {
+  @ApiProperty({ description: 'Identificador único del reporte aprobado' })
+  reportId: number;
+
+  @ApiProperty({ description: 'Título aprobado del reporte', nullable: true })
+  title: string | null;
+
+  @ApiProperty({ description: 'Descripción aprobada del incidente reportado' })
+  description: string;
+
+  @ApiProperty({ description: 'URL del incidente publicado' })
+  incidentUrl: string;
+
+  @ApiProperty({ description: 'Host del medio o publicador original' })
+  publisherHost: string;
+
+  @ApiProperty({ description: 'Fecha de creación del reporte en formato ISO 8601' })
+  createdAt: string;
+
+  @ApiProperty({ description: 'Fecha de aprobación, si está disponible', nullable: true })
+  approvedAt: string | null;
+
+  @ApiProperty({ description: 'Fecha de publicación, si aplica', nullable: true })
+  publishedAt: string | null;
+
+  @ApiProperty({ description: 'Categoría asociada al reporte', type: ReportDetailCategoryDto, nullable: true })
+  category: ReportDetailCategoryDto | null;
+
+  @ApiProperty({ description: 'Información pública del autor según configuración de anonimato' })
+  author: ReportDetailAuthorDto;
+
+  @ApiProperty({ type: [ReportDetailMediaDto], description: 'Listado de archivos aprobados para la revisión' })
+  media: ReportDetailMediaDto[];
+
+  @ApiProperty({ description: 'Promedio de calificaciones del reporte', example: 4.5, type: Number })
+  ratingAverage: number;
+
+  @ApiProperty({ description: 'Cantidad de calificaciones recibidas', example: 12 })
+  ratingCount: number;
+}

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -23,6 +23,7 @@ import { GetReportCommentsQueryDto } from './dto/get-report-comments-query.dto';
 import { GetReportCommentsResponseDto, ReportCommentDto } from './dto/get-report-comments-response.dto';
 import { CreateReportFlagDto } from './dto/create-report-flag.dto';
 import { ReportFlagResponseDto } from './dto/report-flag-response.dto';
+import { ReportDetailDto } from './dto/report-detail.dto';
 
 @ApiTags('Reports')
 @Controller('reports')
@@ -107,6 +108,13 @@ export class ReportsController {
     const userId = Number(req.user.userId);
     await this.reportsService.deleteReport(reportId, { userId });
     return { success: true };
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Obtener detalle de un reporte aprobado' })
+  @ApiOkResponse({ type: ReportDetailDto })
+  async getApprovedReportDetail(@Param('id', ParseIntPipe) reportId: number): Promise<ReportDetailDto> {
+    return this.reportsService.getApprovedReportDetail(reportId);
   }
 
   @Get(':id/comments')

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1,0 +1,134 @@
+import { NotFoundException } from '@nestjs/common';
+import { ReportsService } from './reports.service';
+import type { ReportRepository, ApprovedReportWithRelationsRow, ReportMediaRow } from './report.repository';
+import type { RejectionReasonRepository } from './rejection-reason.repository';
+import type { ReportRatingRepository } from './report-rating.repository';
+import type { ReportCommentRepository } from './report-comment.repository';
+import type { ReportFlagRepository } from './report-flag.repository';
+
+const createReportRepositoryMock = () =>
+  ({
+    findApprovedReportWithRelations: jest.fn(),
+    listMediaByRevision: jest.fn(),
+  }) as jest.Mocked<Pick<ReportRepository, 'findApprovedReportWithRelations' | 'listMediaByRevision'>>;
+
+describe('ReportsService - getApprovedReportDetail', () => {
+  let reportRepository: jest.Mocked<Pick<
+    ReportRepository,
+    'findApprovedReportWithRelations' | 'listMediaByRevision'
+  >>;
+  let service: ReportsService;
+
+  beforeEach(() => {
+    reportRepository = createReportRepositoryMock();
+
+    service = new ReportsService(
+      reportRepository as unknown as ReportRepository,
+      {} as RejectionReasonRepository,
+      {} as ReportRatingRepository,
+      {} as ReportCommentRepository,
+      {} as ReportFlagRepository,
+    );
+  });
+
+  const buildBaseReport = (overrides: Partial<ApprovedReportWithRelationsRow> = {}): ApprovedReportWithRelationsRow => ({
+    reportId: 42,
+    status: 'approved',
+    categoryId: 7,
+    categoryName: 'Fraude',
+    categorySlug: 'fraude',
+    ratingAverage: '4.7500',
+    ratingCount: 8,
+    publishedAt: new Date('2024-01-03T10:00:00.000Z'),
+    approvedAt: new Date('2024-01-02T10:00:00.000Z'),
+    createdAt: new Date('2024-01-01T10:00:00.000Z'),
+    revisionId: 101,
+    title: 'Estafa bancaria confirmada',
+    description: 'Descripción del incidente.',
+    incidentUrl: 'https://example.com/report',
+    publisherHost: 'example.com',
+    isAnonymous: false,
+    authorId: 5,
+    authorFirstName: 'María',
+    authorLastName: 'Pérez',
+    authorUsername: 'maria.perez',
+    ...overrides,
+  });
+
+  const buildMedia = (overrides: Partial<ReportMediaRow> = {}): ReportMediaRow => ({
+    mediaId: 1,
+    revisionId: 101,
+    fileUrl: 'https://cdn.example.com/image.jpg',
+    mediaType: 'image',
+    position: 0,
+    ...overrides,
+  });
+
+  it('should map report detail including media and author display name', async () => {
+    const report = buildBaseReport();
+    const mediaItems = [buildMedia(), buildMedia({ mediaId: 2, fileUrl: 'https://cdn.example.com/image-2.jpg', position: 1 })];
+
+    reportRepository.findApprovedReportWithRelations.mockResolvedValue(report);
+    reportRepository.listMediaByRevision.mockResolvedValue(mediaItems);
+
+    const result = await service.getApprovedReportDetail(report.reportId);
+
+    expect(reportRepository.findApprovedReportWithRelations).toHaveBeenCalledWith(report.reportId);
+    expect(reportRepository.listMediaByRevision).toHaveBeenCalledWith(report.revisionId);
+    expect(result).toEqual({
+      reportId: report.reportId,
+      title: report.title,
+      description: report.description,
+      incidentUrl: report.incidentUrl,
+      publisherHost: report.publisherHost,
+      createdAt: report.createdAt.toISOString(),
+      approvedAt: report.approvedAt?.toISOString() ?? null,
+      publishedAt: report.publishedAt?.toISOString() ?? null,
+      category: { id: report.categoryId!, name: report.categoryName, slug: report.categorySlug },
+      author: { isAnonymous: false, authorId: report.authorId, displayName: 'María Pérez' },
+      media: mediaItems.map((item) => ({
+        mediaId: item.mediaId,
+        fileUrl: item.fileUrl,
+        mediaType: item.mediaType,
+        position: item.position,
+      })),
+      ratingAverage: 4.75,
+      ratingCount: report.ratingCount,
+    });
+  });
+
+  it('should fallback to username when names are not available', async () => {
+    const report = buildBaseReport({ authorFirstName: '  ', authorLastName: '', authorUsername: 'autor.fallback' });
+    reportRepository.findApprovedReportWithRelations.mockResolvedValue(report);
+    reportRepository.listMediaByRevision.mockResolvedValue([buildMedia()]);
+
+    const result = await service.getApprovedReportDetail(report.reportId);
+
+    expect(result.author).toEqual({ isAnonymous: false, authorId: report.authorId, displayName: 'autor.fallback' });
+  });
+
+  it('should hide author details when report is anonymous', async () => {
+    const report = buildBaseReport({ isAnonymous: true });
+    reportRepository.findApprovedReportWithRelations.mockResolvedValue(report);
+    reportRepository.listMediaByRevision.mockResolvedValue([]);
+
+    const result = await service.getApprovedReportDetail(report.reportId);
+
+    expect(result.author).toEqual({ isAnonymous: true, authorId: null, displayName: null });
+  });
+
+  it('should throw NotFound when repository does not return a report', async () => {
+    reportRepository.findApprovedReportWithRelations.mockResolvedValue(undefined);
+
+    await expect(service.getApprovedReportDetail(999)).rejects.toBeInstanceOf(NotFoundException);
+    expect(reportRepository.listMediaByRevision).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFound when report is not approved', async () => {
+    const report = buildBaseReport({ status: 'pending' });
+    reportRepository.findApprovedReportWithRelations.mockResolvedValue(report);
+
+    await expect(service.getApprovedReportDetail(report.reportId)).rejects.toBeInstanceOf(NotFoundException);
+    expect(reportRepository.listMediaByRevision).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add controller endpoint to return approved report details with media and rating stats
- extend the report repository and service to assemble the new ReportDetailDto
- cover the detail workflow with unit tests, including anonymity validation

## Testing
- npm test -- reports

------
https://chatgpt.com/codex/tasks/task_e_68dc8ea4d020832ba4b19b13bf6cd677