### PR TITLE
Configure database connection via ConfigService

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Database connection settings
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=root
+DB_PASSWORD=
+DB_NAME=ofraud

--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@
 $ npm install
 ```
 
+## Environment variables
+
+Create a `.env` file based on the provided `.env.example` to configure the database connection that backs the application.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `DB_HOST` | Hostname or IP address of the MySQL server. | `localhost` |
+| `DB_PORT` | TCP port where the MySQL server listens. | `3306` |
+| `DB_USER` | Username used to authenticate against MySQL. | `root` |
+| `DB_PASSWORD` | Password for the configured MySQL user. | _(empty)_ |
+| `DB_NAME` | Database schema that stores the oFraud tables. | `ofraud` |
+
 ## Compile and run the project
 
 ```bash
@@ -61,7 +73,7 @@ $ npm run test:cov
 
 All environments **must** be provisioned through the versioned migration scripts stored in the `migrations/` directory. This keeps the database schema consistent between development, staging, and production.
 
-1. Configure the database connection by exporting the `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` variables (defaults target `localhost:3306` and database `ofraud`).
+1. Configure the database connection by exporting the `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, and `DB_NAME` variables (the defaults in `.env.example` target `localhost:3306` and database `ofraud`).
 2. Apply migrations in chronological order using `ts-node` or `tsx`. For example:
 
    ```bash

--- a/src/db/db.module.ts
+++ b/src/db/db.module.ts
@@ -1,10 +1,12 @@
 /* eslint-disable prettier/prettier */
 
 import { Global, Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
 import { DbService } from "./db.service";
 
 @Global()
 @Module({
+    imports: [ConfigModule],
     providers: [DbService],
     exports: [DbService],
 })

--- a/src/db/db.service.ts
+++ b/src/db/db.service.ts
@@ -1,26 +1,36 @@
 /* eslint-disable prettier/prettier */
 
 import { Injectable, OnModuleDestroy, OnModuleInit } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
 import { Pool, createPool } from "mysql2/promise";
 
 @Injectable()
-export class DbService implements OnModuleInit, OnModuleDestroy{
+export class DbService implements OnModuleInit, OnModuleDestroy {
     private pool: Pool;
 
-    onModuleInit():void {
+    constructor(private readonly configService: ConfigService) {}
+
+    onModuleInit(): void {
+        const host = this.configService.get<string>("DB_HOST", "localhost");
+        const port = Number(this.configService.get<string>("DB_PORT", "3306"));
+        const user = this.configService.get<string>("DB_USER", "root");
+        const password = this.configService.get<string>("DB_PASSWORD", "");
+        const database = this.configService.get<string>("DB_NAME", "ofraud");
+
         this.pool = createPool({
-            host: 'localhost',
-            user: 'root',
-            password: 'Aroneflaco12&',
-            database: 'ofraud',
-        })
-    }
-    onModuleDestroy() {
-       void this.pool.end();
+            host,
+            port,
+            user,
+            password,
+            database,
+        });
     }
 
-    getPool():Pool{
+    onModuleDestroy(): void {
+        void this.pool.end();
+    }
+
+    getPool(): Pool {
         return this.pool;
     }
-    
 }


### PR DESCRIPTION
## Summary
- inject ConfigService into DbService and build the MySQL pool from environment variables
- expose ConfigModule through DbModule and add a sample .env file with database keys
- document the required database environment variables in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc9702cb78832b8077195fd928c225