### PR TITLE
feat: configure jwt module from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,8 @@ DB_PORT=3306
 DB_USER=root
 DB_PASSWORD=
 DB_NAME=ofraud
+
+# JWT settings
+JWT_SECRET=changeme
+JWT_ACCESS_TTL=15m
+JWT_REFRESH_TTL=7d

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,12 +13,10 @@ import { FilesModule } from './files/files.module';
 import { ReportsModule } from './reports/reports.module';
 import { AdminModule } from './admin/admin.module';
 import { CategoriesModule } from './categories/categories.module';
+import { jwtConfig } from './config/jwt.config';
 
 @Module({
-  imports: [ConfigModule.forRoot({ isGlobal: true }), JwtModule.register({
-      global: true,
-      secret:"supersecret"
-  }), 
+  imports: [ConfigModule.forRoot({ isGlobal: true }), JwtModule.registerAsync(jwtConfig),
   DbModule, UserModule, AuthModule, FilesModule, ReportsModule, AdminModule, CategoriesModule],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/tokens.service.ts
+++ b/src/auth/tokens.service.ts
@@ -1,7 +1,9 @@
 /* eslint-disable prettier/prettier */
 
 import { Injectable } from "@nestjs/common"
+import { ConfigService } from "@nestjs/config"
 import { JwtService } from "@nestjs/jwt"
+import { JWT_ACCESS_TTL, JWT_REFRESH_TTL } from "src/config/jwt.config"
 
 export type UserRole = 'user' | 'admin';
 
@@ -25,15 +27,20 @@ export type RefreshPayload={
 
 @Injectable()
 export class TokenService{
-    constructor (private readonly jwtService: JwtService) {}
+    private readonly accessTokenTtl: string
+    private readonly refreshTokenTtl: string
+
+    constructor (private readonly jwtService: JwtService, private readonly configService: ConfigService) {
+        this.accessTokenTtl = this.configService.get<string>(JWT_ACCESS_TTL, "15m")
+        this.refreshTokenTtl = this.configService.get<string>(JWT_REFRESH_TTL, "7d")
+    }
     async generateAccess(profile:UserProfile): Promise<string>{
         return this.jwtService.signAsync({
             sub: profile.id,
             type: "access",
             profile: profile
         },{
-            expiresIn: "1m",
-            secret: "supersecret"
+            expiresIn: this.accessTokenTtl
         })
     }
 
@@ -42,24 +49,19 @@ export class TokenService{
             sub: userId,
             type: "refresh"
         },{
-            expiresIn: "7d",
-            secret: "supersecret"
+            expiresIn: this.refreshTokenTtl
         })
     }
 
     async verifyAccess(token:string):Promise<AccessPayload>{
-        const payload=await this.jwtService.verifyAsync<AccessPayload>(token,{
-            secret: "supersecret"
-        });
+        const payload=await this.jwtService.verifyAsync<AccessPayload>(token);
         if(payload.type!=="access"){
             throw new Error("Invalid token type");
         }
         return payload;
     }
     async verifyRefresh(token:string):Promise<RefreshPayload>{
-        const payload=await this.jwtService.verifyAsync<RefreshPayload>(token,{
-            secret: "supersecret"
-        });
+        const payload=await this.jwtService.verifyAsync<RefreshPayload>(token);
         if(payload.type!=="refresh"){
             throw new Error("Invalid token type");
         }

--- a/src/config/jwt.config.ts
+++ b/src/config/jwt.config.ts
@@ -1,0 +1,20 @@
+/* eslint-disable prettier/prettier */
+
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModuleAsyncOptions } from '@nestjs/jwt';
+
+export const JWT_SECRET = "JWT_SECRET";
+export const JWT_ACCESS_TTL = "JWT_ACCESS_TTL";
+export const JWT_REFRESH_TTL = "JWT_REFRESH_TTL";
+
+export const jwtConfig: JwtModuleAsyncOptions = {
+    imports: [ConfigModule],
+    inject: [ConfigService],
+    useFactory: (configService: ConfigService) => ({
+        global: true,
+        secret: configService.get<string>(JWT_SECRET),
+        signOptions: {
+            expiresIn: configService.get<string>(JWT_ACCESS_TTL, "15m"),
+        },
+    }),
+};


### PR DESCRIPTION
## Summary
- add a reusable JWT module configuration that reads secret and TTLs from the environment
- wire the application and token service to use the centralized JWT configuration and refreshed lifetimes
- document the new JWT configuration variables in the sample environment file

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc98cc2ba8832b83d85e847a22674e