### PR TITLE
feat: require media attachments when creating reports

### DIFF
--- a/src/reports/dto/create-report.dto.ts
+++ b/src/reports/dto/create-report.dto.ts
@@ -1,6 +1,36 @@
 /* eslint-disable prettier/prettier */
 
-import { IsBoolean, IsInt, IsNotEmpty, IsOptional, IsString, IsUrl, MaxLength } from 'class-validator';
+import {
+  ArrayMaxSize,
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsIn,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUrl,
+  Max,
+  MaxLength,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateReportMediaDto {
+  @IsUrl({ require_tld: false })
+  fileUrl: string;
+
+  @IsIn(['image', 'video'])
+  mediaType: 'image' | 'video';
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  position?: number;
+}
 
 export class CreateReportDto {
   @IsInt()
@@ -26,4 +56,11 @@ export class CreateReportDto {
   @IsString()
   @MaxLength(255)
   publisherHost?: string | null;
+
+  @IsArray()
+  @ArrayMinSize(1)
+  @ArrayMaxSize(5)
+  @ValidateNested({ each: true })
+  @Type(() => CreateReportMediaDto)
+  media: CreateReportMediaDto[];
 }

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -8,7 +8,6 @@ import type { AuthenticatedRequest } from 'src/common/interfaces/authenticated-r
 import { ReportsService } from './reports.service';
 import { CreateReportDto } from './dto/create-report.dto';
 import { UpdateReportDto } from './dto/update-report.dto';
-import { AddMediaDto } from './dto/add-media.dto';
 import { ModerateReportDto } from './dto/moderate-report.dto';
 import { GetReportsQueryDto } from './dto/get-reports-query.dto';
 import { GetReportsResponseDto } from './dto/get-reports-response.dto';
@@ -65,17 +64,6 @@ export class ReportsController {
   ) {
     const userId = Number(req.user.userId);
     return this.reportsService.updateReport(reportId, { userId }, dto);
-  }
-
-  @Post('revisions/:id/media')
-  @UseGuards(JwtAuthGuard)
-  async addMedia(
-    @Req() req: AuthenticatedRequest,
-    @Param('id', ParseIntPipe) revisionId: number,
-    @Body() dto: Omit<AddMediaDto, 'revisionId'>,
-  ) {
-    const userId = Number(req.user.userId);
-    return this.reportsService.addMediaToRevision({ userId }, { ...dto, revisionId });
   }
 
   @Post('moderate')

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -1,6 +1,10 @@
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { ReportsService } from './reports.service';
-import type { ReportRepository, ApprovedReportWithRelationsRow, ReportMediaRow } from './report.repository';
+import type {
+  ReportRepository,
+  ApprovedReportWithRelationsRow,
+  ReportMediaRow,
+} from './report.repository';
 import type { RejectionReasonRepository } from './rejection-reason.repository';
 import type { ReportRatingRepository } from './report-rating.repository';
 import type { ReportCommentRepository } from './report-comment.repository';
@@ -11,6 +15,26 @@ const createReportRepositoryMock = () =>
     findApprovedReportWithRelations: jest.fn(),
     listMediaByRevision: jest.fn(),
   }) as jest.Mocked<Pick<ReportRepository, 'findApprovedReportWithRelations' | 'listMediaByRevision'>>;
+
+const createReportCreationRepositoryMock = () =>
+  ({
+    withTransaction: jest.fn(),
+    createReport: jest.fn(),
+    createRevision: jest.fn(),
+    updateReportCurrentRevision: jest.fn(),
+    appendStatusHistory: jest.fn(),
+    insertMedia: jest.fn(),
+  }) as jest.Mocked<
+    Pick<
+      ReportRepository,
+      | 'withTransaction'
+      | 'createReport'
+      | 'createRevision'
+      | 'updateReportCurrentRevision'
+      | 'appendStatusHistory'
+      | 'insertMedia'
+    >
+  >;
 
 describe('ReportsService - getApprovedReportDetail', () => {
   let reportRepository: jest.Mocked<Pick<
@@ -130,5 +154,98 @@ describe('ReportsService - getApprovedReportDetail', () => {
 
     await expect(service.getApprovedReportDetail(report.reportId)).rejects.toBeInstanceOf(NotFoundException);
     expect(reportRepository.listMediaByRevision).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReportsService - createReport', () => {
+  let reportRepository: ReturnType<typeof createReportCreationRepositoryMock>;
+  let service: ReportsService;
+
+  beforeEach(() => {
+    reportRepository = createReportCreationRepositoryMock();
+    service = new ReportsService(
+      reportRepository as unknown as ReportRepository,
+      {} as RejectionReasonRepository,
+      {} as ReportRatingRepository,
+      {} as ReportCommentRepository,
+      {} as ReportFlagRepository,
+    );
+  });
+
+  it('should create report with media within a transaction', async () => {
+    const mockConnection = Symbol('conn') as unknown as any;
+    reportRepository.withTransaction.mockImplementation(async (handler) => handler(mockConnection));
+    reportRepository.createReport.mockResolvedValue(10);
+    reportRepository.createRevision.mockResolvedValue(20);
+    reportRepository.insertMedia.mockResolvedValueOnce(100).mockResolvedValueOnce(101);
+
+    const dto = {
+      categoryId: 1,
+      description: 'Descripción',
+      incidentUrl: 'https://example.com/caso',
+      media: [
+        { fileUrl: 'https://cdn.example.com/1.jpg', mediaType: 'image' as const },
+        { fileUrl: 'https://cdn.example.com/2.mp4', mediaType: 'video' as const, position: 5 },
+      ],
+    };
+
+    const result = await service.createReport({ userId: 55 }, dto);
+
+    expect(reportRepository.withTransaction).toHaveBeenCalledTimes(1);
+    expect(reportRepository.createReport).toHaveBeenCalledWith(mockConnection, {
+      authorId: 55,
+      categoryId: dto.categoryId,
+      isAnonymous: false,
+    });
+    expect(reportRepository.createRevision).toHaveBeenCalledWith(mockConnection, {
+      reportId: 10,
+      title: null,
+      description: dto.description,
+      incidentUrl: dto.incidentUrl,
+      publisherHost: 'example.com',
+      isAnonymous: false,
+      createdBy: 55,
+      versionNumber: 1,
+    });
+    expect(reportRepository.insertMedia).toHaveBeenNthCalledWith(1, mockConnection, {
+      revisionId: 20,
+      fileUrl: dto.media[0].fileUrl,
+      storageKey: null,
+      mediaType: 'image',
+      position: 1,
+    });
+    expect(reportRepository.insertMedia).toHaveBeenNthCalledWith(2, mockConnection, {
+      revisionId: 20,
+      fileUrl: dto.media[1].fileUrl,
+      storageKey: null,
+      mediaType: 'video',
+      position: 5,
+    });
+    expect(result).toEqual({ reportId: 10, revisionId: 20 });
+  });
+
+  it('should throw when media array is empty', async () => {
+    const dto = {
+      categoryId: 1,
+      description: 'Descripción',
+      incidentUrl: 'https://example.com/caso',
+      media: [],
+    };
+
+    await expect(service.createReport({ userId: 1 }, dto)).rejects.toBeInstanceOf(BadRequestException);
+    expect(reportRepository.withTransaction).not.toHaveBeenCalled();
+  });
+
+  it('should throw when media array exceeds limit', async () => {
+    const baseMedia = { fileUrl: 'https://cdn.example.com/file.jpg', mediaType: 'image' as const };
+    const dto = {
+      categoryId: 1,
+      description: 'Descripción',
+      incidentUrl: 'https://example.com/caso',
+      media: [baseMedia, baseMedia, baseMedia, baseMedia, baseMedia, baseMedia],
+    };
+
+    await expect(service.createReport({ userId: 1 }, dto)).rejects.toBeInstanceOf(BadRequestException);
+    expect(reportRepository.withTransaction).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- extend report creation DTO with validated media items
- store uploaded media during report creation and remove the follow-up media endpoint
- add service tests covering transactional creation and media limits

## Testing
- npm test -- --runTestsByPath src/reports/reports.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dcbf6edaf8832b99e2e57908050610