### PR TITLE
feat: allow video uploads and validate media types

### DIFF
--- a/src/files/file.controller.spec.ts
+++ b/src/files/file.controller.spec.ts
@@ -1,0 +1,44 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  ALLOWED_MIME_TYPES,
+  SUPPORTED_MEDIA_TYPES_DESCRIPTION,
+  fileTypeFilter,
+  isAllowedMimeType,
+} from './file.controller';
+
+describe('FileController configuration', () => {
+  it('includes required video mime types', () => {
+    expect(ALLOWED_MIME_TYPES).toEqual(expect.arrayContaining(['video/mp4', 'video/webm']));
+  });
+
+  it('allows configured video mime types', () => {
+    expect(isAllowedMimeType('video/mp4')).toBe(true);
+    expect(isAllowedMimeType('video/webm')).toBe(true);
+  });
+
+  it('rejects unsupported mime types', () => {
+    expect(isAllowedMimeType('application/pdf')).toBe(false);
+  });
+
+  it('invokes the file filter callback with an error for unsupported mime types', () => {
+    const callback = jest.fn();
+
+    fileTypeFilter({} as any, { mimetype: 'application/pdf' } as Express.Multer.File, callback);
+
+    expect(callback).toHaveBeenCalledTimes(1);
+    const [error, acceptFile] = callback.mock.calls[0];
+    expect(error).toBeInstanceOf(BadRequestException);
+    expect((error as BadRequestException).getResponse()).toMatchObject({
+      message: `Tipo de archivo no permitido. Solo se permiten ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+    });
+    expect(acceptFile).toBe(false);
+  });
+
+  it('accepts supported video mime types through the filter', () => {
+    const callback = jest.fn();
+
+    fileTypeFilter({} as any, { mimetype: 'video/webm' } as Express.Multer.File, callback);
+
+    expect(callback).toHaveBeenCalledWith(null, true);
+  });
+});

--- a/src/files/file.controller.ts
+++ b/src/files/file.controller.ts
@@ -1,24 +1,81 @@
 /* eslint-disable prettier/prettier */
 
 import { BadRequestException, Controller, Post, UploadedFile, UseGuards, UseInterceptors } from "@nestjs/common";
+import { ApiBadRequestResponse, ApiBody, ApiConsumes, ApiCreatedResponse, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { FileInterceptor } from "@nestjs/platform-express";
 import { ConfigService } from "@nestjs/config";
 import { JwtAuthGuard } from "src/common/guards/jwt-auth.guard";
+import type { Request } from "express";
 import { diskStorage } from "multer";
+import type { FileFilterCallback } from "multer";
 import { randomUUID } from "crypto";
 import { existsSync, mkdirSync } from "fs";
 import { extname, join } from "path";
 
 const UPLOAD_FOLDER = join(__dirname, "..", "..", "public", "uploads");
-const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp"];
+export const ALLOWED_MIME_TYPES = [
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "video/mp4",
+    "video/webm",
+] as const;
+export type AllowedMimeType = (typeof ALLOWED_MIME_TYPES)[number];
+export const SUPPORTED_MEDIA_TYPES_DESCRIPTION = "imágenes (JPEG, PNG, WEBP) y videos (MP4, WEBM)";
+export const isAllowedMimeType = (mimetype: string): mimetype is AllowedMimeType =>
+    (ALLOWED_MIME_TYPES as readonly string[]).includes(mimetype);
+export const fileTypeFilter = (req: Request, file: Express.Multer.File, cb: FileFilterCallback) => {
+    if (!isAllowedMimeType(file.mimetype)) {
+        cb(
+            new BadRequestException(
+                `Tipo de archivo no permitido. Solo se permiten ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+            ),
+            false,
+        );
+        return;
+    }
+    cb(null, true);
+};
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
 
 @Controller("files")
+@ApiTags("Files")
 export class FileController {
     constructor(private readonly configService: ConfigService) {}
 
     @Post("upload")
     @UseGuards(JwtAuthGuard)
+    @ApiOperation({
+        summary: "Subir archivo multimedia",
+        description: `Permite subir ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+    })
+    @ApiConsumes("multipart/form-data")
+    @ApiBody({
+        schema: {
+            type: "object",
+            properties: {
+                file: {
+                    type: "string",
+                    format: "binary",
+                    description: `Archivo a cargar. Tipos permitidos: ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+                },
+            },
+            required: ["file"],
+        },
+    })
+    @ApiCreatedResponse({
+        description: `Archivo subido correctamente. Tipos soportados: ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+        schema: {
+            type: "object",
+            properties: {
+                filename: { type: "string" },
+                path: { type: "string" },
+            },
+        },
+    })
+    @ApiBadRequestResponse({
+        description: `Tipo de archivo no permitido. Solo se permiten ${SUPPORTED_MEDIA_TYPES_DESCRIPTION}.`,
+    })
     @UseInterceptors(FileInterceptor("file", {
         storage: diskStorage({
             destination: (req, file, cb) => {
@@ -36,13 +93,7 @@ export class FileController {
         limits: {
             fileSize: MAX_FILE_SIZE_BYTES,
         },
-        fileFilter: (req, file, cb) => {
-            if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
-                cb(new BadRequestException("Tipo de archivo no permitido"), false);
-                return;
-            }
-            cb(null, true);
-        },
+        fileFilter: fileTypeFilter,
     }))
     uploadFile(@UploadedFile() file: Express.Multer.File) {
         if (!file) {

--- a/src/reports/dto/add-media.dto.spec.ts
+++ b/src/reports/dto/add-media.dto.spec.ts
@@ -1,0 +1,37 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { AddMediaDto } from './add-media.dto';
+
+describe('AddMediaDto', () => {
+  const basePayload = {
+    revisionId: 1,
+    fileUrl: 'http://example.com/file.png',
+  } satisfies Partial<AddMediaDto>;
+
+  it('accepts valid video media types', async () => {
+    const dto = plainToInstance(AddMediaDto, {
+      ...basePayload,
+      mediaType: 'video',
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects unsupported media types', async () => {
+    const dto = plainToInstance(AddMediaDto, {
+      ...basePayload,
+      mediaType: 'file',
+    });
+
+    const errors = await validate(dto);
+    const mediaTypeError = errors.find((error) => error.property === 'mediaType');
+
+    expect(mediaTypeError).toBeDefined();
+    expect(mediaTypeError?.constraints?.isIn).toContain('image');
+  });
+});

--- a/src/reports/dto/add-media.dto.ts
+++ b/src/reports/dto/add-media.dto.ts
@@ -14,8 +14,8 @@ export class AddMediaDto {
   storageKey?: string | null;
 
   @IsOptional()
-  @IsIn(['image', 'video', 'file'])
-  mediaType?: 'image' | 'video' | 'file';
+  @IsIn(['image', 'video'])
+  mediaType?: 'image' | 'video';
 
   @IsOptional()
   @IsInt()

--- a/src/reports/dto/create-report.dto.spec.ts
+++ b/src/reports/dto/create-report.dto.spec.ts
@@ -1,0 +1,51 @@
+import 'reflect-metadata';
+
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { CreateReportDto } from './create-report.dto';
+
+describe('CreateReportDto', () => {
+  const basePayload = {
+    categoryId: 1,
+    description: 'Descripción del incidente',
+    incidentUrl: 'http://example.com/caso',
+  } satisfies Partial<CreateReportDto>;
+
+  it('accepts reports with video media entries', async () => {
+    const dto = plainToInstance(CreateReportDto, {
+      ...basePayload,
+      media: [
+        {
+          fileUrl: 'http://example.com/video.mp4',
+          mediaType: 'video',
+        },
+      ],
+    });
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects reports with unsupported media types', async () => {
+    const dto = plainToInstance(CreateReportDto, {
+      ...basePayload,
+      media: [
+        {
+          fileUrl: 'http://example.com/document.pdf',
+          mediaType: 'document',
+        },
+      ],
+    });
+
+    const errors = await validate(dto);
+    const mediaErrors = errors.find((error) => error.property === 'media');
+    const mediaTypeError = mediaErrors?.children?.[0]?.children?.find(
+      (child) => child.property === 'mediaType',
+    );
+
+    expect(mediaErrors).toBeDefined();
+    expect(mediaTypeError?.constraints?.isIn).toContain('image');
+  });
+});


### PR DESCRIPTION
## Summary
- allow video uploads by expanding the file controller validation and documenting supported formats in Swagger
- tighten media DTO validation to accept only images or videos and share clearer error messages
- add unit tests for file uploads and DTOs covering valid videos and rejecting unsupported types

## Testing
- npm test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd68500b64832b94d2ae087f894710