### PR TITLE
Include removed reports in author queries

### DIFF
--- a/src/reports/dto/get-my-reports-query.dto.ts
+++ b/src/reports/dto/get-my-reports-query.dto.ts
@@ -13,14 +13,14 @@ export class GetMyReportsQueryDto {
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  page?: number;
+  page: number = 1;
 
   @ApiPropertyOptional({ description: 'Cantidad de reportes por página', example: 10 })
   @IsOptional()
   @Type(() => Number)
   @IsInt()
   @Min(1)
-  limit?: number;
+  limit: number = 10;
 
   @ApiPropertyOptional({ description: 'Filtrar reportes por estado actual', enum: REPORT_STATUS_VALUES })
   @IsOptional()

--- a/src/reports/report.repository.ts
+++ b/src/reports/report.repository.ts
@@ -605,8 +605,13 @@ export class ReportRepository {
   }): Promise<{ items: AuthorReportRow[]; total: number }> {
     const { authorId, status, limit, offset } = params;
 
-    const conditions = ['r.author_id = ?', 'r.deleted_at IS NULL'];
+    const conditions = ['r.author_id = ?'];
     const values: Array<number | string> = [authorId];
+
+    const shouldIncludeDeleted = !status || status === 'removed';
+    if (!shouldIncludeDeleted) {
+      conditions.push('r.deleted_at IS NULL');
+    }
 
     if (status) {
       conditions.push('r.status = ?');


### PR DESCRIPTION
## Summary
- update the reports repository so author listings keep soft-deleted rows when requesting removed status or without filters
- default the my-reports query DTO pagination fields so validation still succeeds during tests
- extend the e2e suite with removed-report coverage and required mocks/configuration

## Testing
- npm run test:e2e -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68dd6d038904832b942bf7282a1b24da