### PR TITLE
feat: add admin dashboard frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # compiled output
 /dist
 /node_modules
+/frontend/node_modules
+/frontend/dist
 /build
 
 # Logs

--- a/README.md
+++ b/README.md
@@ -56,6 +56,35 @@ $ npm run start:dev
 $ npm run start:prod
 ```
 
+## Admin dashboard (React)
+
+The repository now includes a Vite + React dashboard inside the `frontend/` directory to help administrators moderate
+fraud reports and track key indicators exposed by the API.
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+By default the dashboard expects the API to be available at `http://localhost:3000`. You can override that origin by
+creating a `.env` file in `frontend/` with a `VITE_API_BASE_URL` entry, for example:
+
+```bash
+VITE_API_BASE_URL=https://api.ofraud.test
+```
+
+### Dashboard features
+
+- **Authentication**: Admins can log in with their credentials. The dashboard stores and refreshes access tokens
+  transparently using the `/auth/login`, `/auth/profile`, and `/auth/refresh` endpoints.
+- **Overview**: Visualize system metrics such as report totals, moderation workload, and the top categories/hosts sourced
+  from `/admin/metrics/*` and `/insights/fraud-stats`.
+- **Report moderation**: Review, approve, reject, or remove community reports through `/admin/reports` and
+  `/reports/moderate`.
+- **Community alerts**: Validate or dismiss report flags using `/admin/report-flags` and `/admin/report-flags/:id`.
+- **Category management**: Create or edit report categories with `/admin/categories`.
+
 ## Run tests
 
 ```bash

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>oFraud | Panel de administración</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ofraud-admin-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@heroicons/react": "^2.1.5",
+    "@tanstack/react-query": "^5.62.8",
+    "jwt-decode": "^4.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.28.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.7",
+    "@vitejs/plugin-react": "^4.3.4",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.1"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,30 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { ProtectedRoute } from './components/ProtectedRoute';
+import { DashboardLayout } from './components/Layout';
+import { LoginPage } from './pages/LoginPage';
+import { DashboardPage } from './pages/DashboardPage';
+import { ReportsPage } from './pages/ReportsPage';
+import { ReportFlagsPage } from './pages/ReportFlagsPage';
+import { CategoriesPage } from './pages/CategoriesPage';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route path="/login" element={<LoginPage />} />
+      <Route
+        element={
+          <ProtectedRoute>
+            <DashboardLayout />
+          </ProtectedRoute>
+        }
+      >
+        <Route index element={<Navigate to="/dashboard" replace />} />
+        <Route path="/dashboard" element={<DashboardPage />} />
+        <Route path="/reports" element={<ReportsPage />} />
+        <Route path="/report-flags" element={<ReportFlagsPage />} />
+        <Route path="/categories" element={<CategoriesPage />} />
+      </Route>
+      <Route path="*" element={<Navigate to="/dashboard" replace />} />
+    </Routes>
+  );
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1,0 +1,150 @@
+export type ReportStatus = 'pending' | 'approved' | 'rejected' | 'removed';
+
+export type MetricsOverview = {
+  totalUsers: number;
+  blockedUsers: number;
+  totalReports: number;
+  approvedReports: number;
+  pendingReports: number;
+  totalFlags: number;
+  pendingFlags: number;
+  validatedFlags: number;
+  dismissedFlags: number;
+};
+
+export type MetricsTopCategory = {
+  id: number;
+  name: string;
+  slug: string;
+  reportsCount: number;
+  searchCount: number;
+};
+
+export type MetricsTopHost = {
+  host: string;
+  reportsCount: number;
+  approvedReportsCount: number;
+  pendingReportsCount: number;
+  rejectedReportsCount: number;
+  removedReportsCount: number;
+};
+
+export type FraudStats = {
+  averageDetectionDays: number;
+  totalReportsApproved: number;
+  reportsThisWeek: number;
+  reportsThisMonth: number;
+  totalActiveUsers: number;
+  categoriesCount: number;
+};
+
+export type AdminReport = {
+  reportId: number;
+  title: string | null;
+  status: ReportStatus;
+  categoryId: number;
+  categoryName: string | null;
+  author: {
+    id: number;
+    email: string | null;
+    name: string | null;
+  };
+  reviewer: {
+    id: number;
+    name: string | null;
+  } | null;
+  createdAt: string;
+  updatedAt: string;
+  reviewedAt: string | null;
+  publishedAt: string | null;
+  reviewNotes: string | null;
+  rejectionReasonText: string | null;
+};
+
+export type PaginationMeta = {
+  page: number;
+  limit: number;
+  total: number;
+};
+
+export type AdminReportsResponse = {
+  items: AdminReport[];
+  meta: PaginationMeta;
+};
+
+export type ReportFlagStatus = 'pending' | 'validated' | 'dismissed';
+export type ReportFlagReason =
+  | 'duplicate'
+  | 'false-information'
+  | 'spam'
+  | 'offensive-content'
+  | 'other';
+
+export type AdminReportFlag = {
+  flagId: number;
+  reportId: number;
+  reportTitle: string | null;
+  reportStatus: ReportStatus;
+  reasonCode: ReportFlagReason;
+  details: string | null;
+  status: ReportFlagStatus;
+  createdAt: string;
+  handledAt: string | null;
+  reporter: {
+    id: number;
+    email: string | null;
+    name: string | null;
+  };
+  handler: {
+    id: number;
+    name: string | null;
+  } | null;
+};
+
+export type AdminReportFlagsResponse = {
+  items: AdminReportFlag[];
+  meta: PaginationMeta;
+  counts: {
+    pending: number;
+    validated: number;
+    dismissed: number;
+  };
+};
+
+export type Category = {
+  id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  is_active: boolean;
+  reports_count: number;
+  search_count: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CreateCategoryPayload = {
+  name: string;
+  slug: string;
+  description?: string | null;
+  is_active?: boolean;
+};
+
+export type UpdateCategoryPayload = Partial<CreateCategoryPayload> & {
+  reports_count?: number;
+  search_count?: number;
+};
+
+export type ModerateReportPayload = {
+  action: 'approve' | 'reject';
+  reportId: number;
+  revisionId?: number;
+  rejectionReasonId?: number;
+  rejectionReasonCode?: string | null;
+  rejectionReasonText?: string | null;
+  note?: string | null;
+};
+
+export type ResolveReportFlagPayload = {
+  status: ReportFlagStatus;
+};

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,26 @@
+import { useAuth } from '../hooks/useAuth';
+
+export function HeaderBar() {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className="header">
+      <div>
+        <h1 className="header__title">Panel de monitoreo</h1>
+        <p className="header__subtitle">Gestiona los reportes y métricas de la comunidad</p>
+      </div>
+      <div className="header__actions">
+        <div className="header__user">
+          <span className="header__avatar">{user?.name?.charAt(0) ?? 'A'}</span>
+          <div>
+            <p className="header__user-name">{user?.name ?? 'Administrador'}</p>
+            <p className="header__user-role">{user?.email ?? 'sin correo'}</p>
+          </div>
+        </div>
+        <button className="button button--ghost" type="button" onClick={logout}>
+          Cerrar sesión
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from 'react-router-dom';
+import { Sidebar } from './Sidebar';
+import { HeaderBar } from './Header';
+
+export function DashboardLayout() {
+  return (
+    <div className="dashboard-layout">
+      <Sidebar />
+      <div className="dashboard-main">
+        <HeaderBar />
+        <main className="dashboard-content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MetricCard.tsx
+++ b/frontend/src/components/MetricCard.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from 'react';
+
+export function MetricCard({ title, value, helper }: { title: string; value: ReactNode; helper?: ReactNode }) {
+  return (
+    <article className="metric-card">
+      <p className="metric-card__title">{title}</p>
+      <p className="metric-card__value">{value}</p>
+      {helper && <p className="metric-card__helper">{helper}</p>}
+    </article>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+export function Modal({ open, title, onClose, children }: { open: boolean; title: string; onClose: () => void; children: ReactNode }) {
+  if (!open) return null;
+  return (
+    <div className="modal">
+      <div className="modal__backdrop" onClick={onClose} role="presentation" />
+      <div className="modal__content">
+        <div className="modal__header">
+          <h2>{title}</h2>
+          <button className="button button--ghost" type="button" onClick={onClose}>
+            Cerrar
+          </button>
+        </div>
+        <div className="modal__body">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Pagination.tsx
+++ b/frontend/src/components/Pagination.tsx
@@ -1,0 +1,21 @@
+export function Pagination({ page, total, limit, onPageChange }: { page: number; total: number; limit: number; onPageChange: (page: number) => void }) {
+  const totalPages = Math.max(1, Math.ceil(total / limit));
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="pagination">
+      <button className="button button--ghost" type="button" disabled={!canPrev} onClick={() => canPrev && onPageChange(page - 1)}>
+        Anterior
+      </button>
+      <span>
+        Página {page} de {totalPages}
+      </span>
+      <button className="button button--ghost" type="button" disabled={!canNext} onClick={() => canNext && onPageChange(page + 1)}>
+        Siguiente
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,22 @@
+import { Navigate, useLocation } from 'react-router-dom';
+import { ReactNode } from 'react';
+import { useAuth } from '../hooks/useAuth';
+
+export function ProtectedRoute({ children }: { children: ReactNode }) {
+  const { isAuthenticated, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center bg-slate-950 text-slate-200">
+        Cargando panel de administración…
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,0 +1,34 @@
+import { NavLink } from 'react-router-dom';
+import { ChartBarIcon, ClipboardDocumentListIcon, FlagIcon, Squares2X2Icon } from '@heroicons/react/24/outline';
+
+const navItems = [
+  { to: '/dashboard', label: 'Resumen', icon: ChartBarIcon },
+  { to: '/reports', label: 'Reportes', icon: ClipboardDocumentListIcon },
+  { to: '/report-flags', label: 'Alertas', icon: FlagIcon },
+  { to: '/categories', label: 'Categorías', icon: Squares2X2Icon },
+];
+
+export function Sidebar() {
+  return (
+    <aside className="sidebar">
+      <div className="sidebar__brand">
+        <span className="sidebar__logo">oFraud</span>
+        <p className="sidebar__subtitle">Panel administrativo</p>
+      </div>
+      <nav className="sidebar__nav">
+        {navItems.map(({ to, label, icon: Icon }) => (
+          <NavLink
+            key={to}
+            to={to}
+            className={({ isActive }) =>
+              `sidebar__link ${isActive ? 'sidebar__link--active' : ''}`
+            }
+          >
+            <Icon className="sidebar__icon" />
+            <span>{label}</span>
+          </NavLink>
+        ))}
+      </nav>
+    </aside>
+  );
+}

--- a/frontend/src/components/StatusBadge.tsx
+++ b/frontend/src/components/StatusBadge.tsx
@@ -1,0 +1,36 @@
+import { ReportStatus, ReportFlagStatus } from '../api/types';
+
+const statusStyles: Record<string, { background: string; color: string; border: string }> = {
+  pending: { background: 'rgba(245, 158, 11, 0.12)', color: '#fcd34d', border: 'rgba(245, 158, 11, 0.4)' },
+  approved: { background: 'rgba(16, 185, 129, 0.12)', color: '#6ee7b7', border: 'rgba(16, 185, 129, 0.4)' },
+  rejected: { background: 'rgba(248, 113, 113, 0.12)', color: '#fca5a5', border: 'rgba(248, 113, 113, 0.4)' },
+  removed: { background: 'rgba(100, 116, 139, 0.12)', color: '#e2e8f0', border: 'rgba(100, 116, 139, 0.4)' },
+  validated: { background: 'rgba(16, 185, 129, 0.12)', color: '#6ee7b7', border: 'rgba(16, 185, 129, 0.4)' },
+  dismissed: { background: 'rgba(100, 116, 139, 0.12)', color: '#e2e8f0', border: 'rgba(100, 116, 139, 0.4)' },
+};
+
+const statusLabels: Record<string, string> = {
+  pending: 'Pendiente',
+  approved: 'Aprobado',
+  rejected: 'Rechazado',
+  removed: 'Eliminado',
+  validated: 'Validado',
+  dismissed: 'Descartado',
+};
+
+export function StatusBadge({ status }: { status: ReportStatus | ReportFlagStatus }) {
+  const style = statusStyles[status] ?? {
+    background: 'rgba(148, 163, 184, 0.2)',
+    color: '#e2e8f0',
+    border: 'rgba(148, 163, 184, 0.4)',
+  };
+  const label = statusLabels[status] ?? status;
+  return (
+    <span
+      className="status-badge"
+      style={{ backgroundColor: style.background, color: style.color, border: `1px solid ${style.border}` }}
+    >
+      {label}
+    </span>
+  );
+}

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,206 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+
+export type AuthUser = {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+};
+
+type SessionPayload = {
+  accessToken: string;
+  refreshToken: string | null;
+  user?: AuthUser | null;
+};
+
+type AuthContextValue = {
+  user: AuthUser | null;
+  accessToken: string | null;
+  refreshToken: string | null;
+  loading: boolean;
+  isAuthenticated: boolean;
+  login: (credentials: { email: string; password: string }) => Promise<void>;
+  logout: () => void;
+  setTokens: (tokens: { accessToken: string; refreshToken?: string }) => void;
+};
+
+const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL ?? 'http://localhost:3000';
+const STORAGE_KEY = 'ofraud.admin.session';
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+async function readJson<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  if (!text) {
+    return {} as T;
+  }
+  return JSON.parse(text) as T;
+}
+
+type LoginResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+type ProfileResponse = {
+  profile: AuthUser;
+};
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const persistSession = useCallback((payload: SessionPayload | null) => {
+    if (!payload) {
+      localStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        accessToken: payload.accessToken,
+        refreshToken: payload.refreshToken,
+        user: payload.user ?? null,
+      }),
+    );
+  }, []);
+
+  const logout = useCallback(() => {
+    setUser(null);
+    setAccessToken(null);
+    setRefreshToken(null);
+    persistSession(null);
+  }, [persistSession]);
+
+  const loadProfile = useCallback(
+    async (token: string) => {
+      const response = await fetch(`${API_BASE_URL}/auth/profile`, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error('No se pudo obtener el perfil');
+      }
+
+      const data = await readJson<ProfileResponse>(response);
+      setUser(data.profile);
+      return data.profile;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const session = JSON.parse(stored) as SessionPayload;
+      if (session.accessToken) {
+        setAccessToken(session.accessToken);
+        setRefreshToken(session.refreshToken ?? null);
+        if (session.user) {
+          setUser(session.user);
+          setLoading(false);
+        } else {
+          loadProfile(session.accessToken)
+            .catch(() => {
+              logout();
+            })
+            .finally(() => setLoading(false));
+          return;
+        }
+      }
+    } catch (error) {
+      console.error('Error al cargar la sesión', error);
+      persistSession(null);
+    }
+    setLoading(false);
+  }, [loadProfile, logout, persistSession]);
+
+  const login = useCallback(
+    async (credentials: { email: string; password: string }) => {
+      setLoading(true);
+      try {
+        const response = await fetch(`${API_BASE_URL}/auth/login`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(credentials),
+        });
+
+        if (!response.ok) {
+          const errorPayload = await response.json().catch(() => ({}));
+          const message =
+            typeof errorPayload.message === 'string'
+              ? errorPayload.message
+              : Array.isArray(errorPayload.message)
+              ? errorPayload.message.join(', ')
+              : 'Credenciales inválidas';
+          throw new Error(message);
+        }
+
+        const data = (await readJson<LoginResponse>(response));
+        setAccessToken(data.accessToken);
+        setRefreshToken(data.refreshToken);
+
+        const profile = await loadProfile(data.accessToken);
+        persistSession({ accessToken: data.accessToken, refreshToken: data.refreshToken, user: profile });
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loadProfile, persistSession],
+  );
+
+  const setTokens = useCallback(
+    ({ accessToken: newAccessToken, refreshToken: newRefreshToken }: { accessToken: string; refreshToken?: string }) => {
+      setAccessToken(newAccessToken);
+      const effectiveRefresh = newRefreshToken ?? refreshToken ?? null;
+      if (newRefreshToken !== undefined) {
+        setRefreshToken(newRefreshToken ?? null);
+      }
+      persistSession({ accessToken: newAccessToken, refreshToken: effectiveRefresh, user });
+    },
+    [persistSession, refreshToken, user],
+  );
+
+  const value = useMemo(
+    () => ({
+      user,
+      accessToken,
+      refreshToken,
+      loading,
+      isAuthenticated: Boolean(accessToken),
+      login,
+      logout,
+      setTokens,
+    }),
+    [accessToken, loading, login, logout, refreshToken, setTokens, user],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuthContext(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuthContext debe utilizarse dentro de AuthProvider');
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -1,0 +1,141 @@
+import { useCallback } from 'react';
+import { useAuth } from './useAuth';
+
+const API_BASE_URL = (import.meta as any).env?.VITE_API_BASE_URL ?? 'http://localhost:3000';
+
+type RequestOptions = RequestInit & {
+  skipAuth?: boolean;
+};
+
+async function parseResponse(response: Response) {
+  if (response.status === 204) {
+    return null;
+  }
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    console.error('No se pudo parsear la respuesta JSON', error);
+    return text;
+  }
+}
+
+export function useApi() {
+  const { accessToken, refreshToken, setTokens, logout } = useAuth();
+
+  const request = useCallback(
+    async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+      const { skipAuth, headers, body, ...rest } = options;
+      const requestInit: RequestInit = {
+        ...rest,
+        headers: {
+          ...(headers ?? {}),
+        },
+      };
+
+      if (body && typeof body === 'object' && !(body instanceof FormData)) {
+        requestInit.headers = {
+          'Content-Type': 'application/json',
+          ...(requestInit.headers as Record<string, string>),
+        };
+        requestInit.body = JSON.stringify(body);
+      } else if (body instanceof FormData) {
+        requestInit.body = body;
+        delete (requestInit.headers as Record<string, string>)['Content-Type'];
+      } else if (typeof body === 'string') {
+        requestInit.headers = {
+          'Content-Type': 'application/json',
+          ...(requestInit.headers as Record<string, string>),
+        };
+        requestInit.body = body;
+      }
+
+      const withToken = (token: string | null) => ({
+        ...(requestInit.headers ?? {}),
+        ...(token && !skipAuth ? { Authorization: `Bearer ${token}` } : {}),
+      });
+
+      let currentToken = accessToken;
+      let response = await fetch(`${API_BASE_URL}${path}`, {
+        ...requestInit,
+        headers: withToken(currentToken),
+      });
+
+      if (response.status === 401 && !skipAuth && refreshToken) {
+        const refreshResponse = await fetch(`${API_BASE_URL}/auth/refresh`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ refreshToken }),
+        });
+
+        if (refreshResponse.ok) {
+          const refreshData = await parseResponse(refreshResponse);
+          const newAccessToken = refreshData?.accessToken;
+          if (typeof newAccessToken === 'string') {
+            currentToken = newAccessToken;
+            setTokens({ accessToken: newAccessToken });
+            response = await fetch(`${API_BASE_URL}${path}`, {
+              ...requestInit,
+              headers: withToken(currentToken),
+            });
+          } else {
+            logout();
+            throw new Error('Sesión expirada');
+          }
+        } else {
+          logout();
+          throw new Error('Sesión expirada');
+        }
+      }
+
+      if (!response.ok) {
+        const errorPayload = await parseResponse(response);
+        const message =
+          typeof errorPayload?.message === 'string'
+            ? errorPayload.message
+            : Array.isArray(errorPayload?.message)
+            ? errorPayload.message.join(', ')
+            : response.statusText;
+        throw new Error(message || 'Error inesperado en la API');
+      }
+
+      return parseResponse(response) as Promise<T>;
+    },
+    [accessToken, logout, refreshToken, setTokens],
+  );
+
+  const get = useCallback(
+    <T>(path: string, init?: RequestOptions) => request<T>(path, { method: 'GET', ...(init ?? {}) }),
+    [request],
+  );
+
+  const post = useCallback(
+    <T>(path: string, body?: unknown, init?: RequestOptions) =>
+      request<T>(path, { method: 'POST', body, ...(init ?? {}) }),
+    [request],
+  );
+
+  const patch = useCallback(
+    <T>(path: string, body?: unknown, init?: RequestOptions) =>
+      request<T>(path, { method: 'PATCH', body, ...(init ?? {}) }),
+    [request],
+  );
+
+  const put = useCallback(
+    <T>(path: string, body?: unknown, init?: RequestOptions) =>
+      request<T>(path, { method: 'PUT', body, ...(init ?? {}) }),
+    [request],
+  );
+
+  const del = useCallback(
+    <T>(path: string, init?: RequestOptions) => request<T>(path, { method: 'DELETE', ...(init ?? {}) }),
+    [request],
+  );
+
+  return { request, get, post, patch, put, del };
+}

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,5 @@
+import { useAuthContext } from '../context/AuthContext';
+
+export function useAuth() {
+  return useAuthContext();
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,626 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background-color: #0f172a;
+  color: #e2e8f0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body,
+html,
+#root {
+  margin: 0;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font-family: inherit;
+}
+
+input,
+select,
+textarea,
+button {
+  border: none;
+  outline: none;
+}
+
+body {
+  background: linear-gradient(180deg, #0f172a 0%, #1e293b 100%);
+}
+
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.dashboard-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: rgba(15, 23, 42, 0.95);
+  backdrop-filter: blur(12px);
+  border-right: 1px solid rgba(148, 163, 184, 0.1);
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sidebar__brand {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.sidebar__logo {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #38bdf8;
+}
+
+.sidebar__subtitle {
+  margin: 0;
+  color: #cbd5f5;
+  font-size: 0.95rem;
+}
+
+.sidebar__nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar__link {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  color: #cbd5f5;
+  font-weight: 500;
+  transition: background 0.2s, color 0.2s;
+}
+
+.sidebar__link:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.sidebar__link--active {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(56, 189, 248, 0.04));
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  color: #f8fafc;
+}
+
+.sidebar__icon {
+  width: 20px;
+  height: 20px;
+}
+
+.dashboard-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.1);
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(12px);
+}
+
+.header__title {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #e0f2fe;
+}
+
+.header__subtitle {
+  margin: 0.25rem 0 0;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.header__actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header__user {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.header__avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 9999px;
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.header__user-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.header__user-role {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.dashboard-content {
+  flex: 1;
+  padding: 2rem;
+  background: radial-gradient(circle at top right, rgba(56, 189, 248, 0.08), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(99, 102, 241, 0.08), transparent 55%);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.stack--lg {
+  gap: 2rem;
+}
+
+.card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
+}
+
+.card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #e0f2fe;
+}
+
+.card__subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.card__filters {
+  display: flex;
+  gap: 1rem;
+}
+
+.card__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.card__select {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  color: #f8fafc;
+}
+
+.card__error {
+  background: rgba(248, 113, 113, 0.1);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.card__success {
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid rgba(16, 185, 129, 0.4);
+  color: #bbf7d0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.card__chips {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  color: rgba(148, 163, 184, 0.85);
+  margin-bottom: 1rem;
+}
+
+.button {
+  border-radius: 9999px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.button--primary {
+  background: linear-gradient(135deg, #38bdf8, #6366f1);
+  color: #0f172a;
+  border: none;
+}
+
+.button--ghost {
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  color: #e2e8f0;
+}
+
+.button--danger {
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(56, 189, 248, 0.15);
+}
+
+.metric-card {
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.metric-card__title {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.metric-card__value {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 700;
+  color: #f8fafc;
+}
+
+.metric-card__helper {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.75);
+}
+
+.grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.grid--metrics {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.grid--two-cols {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.grid--stats {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.list__item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.08);
+}
+
+.list__title {
+  margin: 0;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.list__subtitle {
+  margin: 0.35rem 0 0;
+  color: rgba(148, 163, 184, 0.7);
+  font-size: 0.85rem;
+}
+
+.list__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  color: rgba(148, 163, 184, 0.8);
+  text-align: right;
+}
+
+.stat__label {
+  margin: 0;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.9rem;
+}
+
+.stat__value {
+  margin: 0.35rem 0 0;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 780px;
+}
+
+.table th,
+.table td {
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.table th {
+  color: rgba(148, 163, 184, 0.85);
+  font-weight: 600;
+}
+
+.table__meta {
+  margin: 0.25rem 0 0;
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.6);
+}
+
+.table__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.pagination {
+  margin-top: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: flex-end;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(6px);
+}
+
+.modal__content {
+  position: relative;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  padding: 2rem;
+  border-radius: 1.25rem;
+  width: min(480px, 90vw);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.45);
+  z-index: 1;
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.modal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.form__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.form__input,
+.form__textarea {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.65);
+  padding: 0.75rem;
+  color: #f8fafc;
+}
+
+.form__textarea {
+  resize: vertical;
+}
+
+.form__checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.form__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+}
+
+.login {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(99, 102, 241, 0.2), transparent 55%);
+}
+
+.login__card {
+  width: min(420px, 100%);
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.45);
+}
+
+.login__title {
+  margin: 0;
+  font-size: 1.75rem;
+  color: #f8fafc;
+}
+
+.login__subtitle {
+  margin: 0.5rem 0 2rem;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.login__form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.login__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.login__input {
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.7);
+  padding: 0.75rem;
+  color: #f8fafc;
+}
+
+.login__error {
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.4);
+  color: #fecaca;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+}
+
+@media (max-width: 960px) {
+  .dashboard-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sidebar__nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .dashboard-main {
+    padding-top: 0;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,21 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
+
+const queryClient = new QueryClient();
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </AuthProvider>
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -1,0 +1,229 @@
+import { FormEvent, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useApi } from '../hooks/useApi';
+import type { Category } from '../api/types';
+import { formatDateTime, formatNumber } from '../utils/format';
+
+const emptyForm = {
+  name: '',
+  slug: '',
+  description: '',
+  is_active: true,
+};
+
+type CategoryFormState = typeof emptyForm & { reports_count?: number; search_count?: number };
+
+export function CategoriesPage() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<CategoryFormState>(emptyForm);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const categoriesQuery = useQuery({
+    queryKey: ['admin-categories'],
+    queryFn: () => api.get<Category[]>('/admin/categories'),
+  });
+
+  const resetForm = () => {
+    setForm(emptyForm);
+    setEditingId(null);
+  };
+
+  const handleEdit = (category: Category) => {
+    setEditingId(category.id);
+    setForm({
+      name: category.name,
+      slug: category.slug,
+      description: category.description ?? '',
+      is_active: category.is_active,
+      reports_count: category.reports_count,
+      search_count: category.search_count,
+    });
+  };
+
+  const handleChange = (field: keyof CategoryFormState, value: string | boolean | number) => {
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    try {
+      if (!form.name || !form.slug) {
+        throw new Error('Completa el nombre y el slug de la categoría');
+      }
+
+      if (editingId) {
+        await api.put(`/admin/categories/${editingId}`, {
+          name: form.name,
+          slug: form.slug,
+          description: form.description || null,
+          is_active: form.is_active,
+          reports_count: form.reports_count,
+          search_count: form.search_count,
+        });
+        setSuccess('Categoría actualizada correctamente');
+      } else {
+        await api.post('/admin/categories', {
+          name: form.name,
+          slug: form.slug,
+          description: form.description || null,
+          is_active: form.is_active,
+        });
+        setSuccess('Categoría creada con éxito');
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ['admin-categories'] });
+      resetForm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo guardar la categoría');
+    }
+  };
+
+  return (
+    <div className="grid grid--two-cols">
+      <section className="card">
+        <h2 className="card__title">Categorías</h2>
+        {categoriesQuery.isLoading && <p>Cargando categorías…</p>}
+        {categoriesQuery.isError && (
+          <p className="card__error">No se pudieron cargar las categorías: {(categoriesQuery.error as Error).message}</p>
+        )}
+
+        {categoriesQuery.data && categoriesQuery.data.length === 0 && <p>No hay categorías registradas.</p>}
+
+        {categoriesQuery.data && categoriesQuery.data.length > 0 && (
+          <div className="table-wrapper">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Nombre</th>
+                  <th>Slug</th>
+                  <th>Reportes</th>
+                  <th>Búsquedas</th>
+                  <th>Estado</th>
+                  <th>Actualizado</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {categoriesQuery.data.map((category) => (
+                  <tr key={category.id}>
+                    <td>{category.name}</td>
+                    <td>{category.slug}</td>
+                    <td>{formatNumber(category.reports_count)}</td>
+                    <td>{formatNumber(category.search_count)}</td>
+                    <td>{category.is_active ? 'Activa' : 'Inactiva'}</td>
+                    <td>{formatDateTime(category.updated_at)}</td>
+                    <td>
+                      <button className="button button--ghost" type="button" onClick={() => handleEdit(category)}>
+                        Editar
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section className="card">
+        <h2 className="card__title">{editingId ? 'Editar categoría' : 'Nueva categoría'}</h2>
+        <p className="card__subtitle">
+          {editingId
+            ? 'Actualiza la información de la categoría seleccionada.'
+            : 'Crea categorías para organizar los reportes del sistema.'}
+        </p>
+
+        {error && <p className="card__error">{error}</p>}
+        {success && <p className="card__success">{success}</p>}
+
+        <form className="form" onSubmit={handleSubmit}>
+          <label className="form__label">
+            Nombre
+            <input
+              className="form__input"
+              type="text"
+              value={form.name}
+              onChange={(event) => handleChange('name', event.target.value)}
+              placeholder="Nombre descriptivo"
+              required
+            />
+          </label>
+
+          <label className="form__label">
+            Slug
+            <input
+              className="form__input"
+              type="text"
+              value={form.slug}
+              onChange={(event) => handleChange('slug', event.target.value)}
+              placeholder="ej. fraude-digital"
+              required
+            />
+          </label>
+
+          <label className="form__label">
+            Descripción
+            <textarea
+              className="form__textarea"
+              value={form.description}
+              onChange={(event) => handleChange('description', event.target.value)}
+              placeholder="Explica el tipo de fraude cubierto por esta categoría"
+              rows={3}
+            />
+          </label>
+
+          <label className="form__checkbox">
+            <input
+              type="checkbox"
+              checked={form.is_active}
+              onChange={(event) => handleChange('is_active', event.target.checked)}
+            />
+            Categoría activa para nuevos reportes
+          </label>
+
+          {editingId && (
+            <div className="form__grid">
+              <label className="form__label">
+                Reportes asociados
+                <input
+                  className="form__input"
+                  type="number"
+                  min={0}
+                  value={form.reports_count ?? 0}
+                  onChange={(event) => handleChange('reports_count', Number(event.target.value))}
+                />
+              </label>
+              <label className="form__label">
+                Búsquedas
+                <input
+                  className="form__input"
+                  type="number"
+                  min={0}
+                  value={form.search_count ?? 0}
+                  onChange={(event) => handleChange('search_count', Number(event.target.value))}
+                />
+              </label>
+            </div>
+          )}
+
+          <div className="form__actions">
+            {editingId && (
+              <button className="button button--ghost" type="button" onClick={resetForm}>
+                Cancelar edición
+              </button>
+            )}
+            <button className="button button--primary" type="submit">
+              {editingId ? 'Actualizar' : 'Crear categoría'}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,0 +1,141 @@
+import { useQuery } from '@tanstack/react-query';
+import { MetricCard } from '../components/MetricCard';
+import { useApi } from '../hooks/useApi';
+import { formatNumber } from '../utils/format';
+import type {
+  MetricsOverview,
+  MetricsTopCategory,
+  MetricsTopHost,
+  FraudStats,
+} from '../api/types';
+
+export function DashboardPage() {
+  const api = useApi();
+
+  const metricsQuery = useQuery({
+    queryKey: ['metrics-overview'],
+    queryFn: () => api.get<MetricsOverview>('/admin/metrics/overview'),
+  });
+
+  const topCategoriesQuery = useQuery({
+    queryKey: ['metrics-top-categories'],
+    queryFn: () => api.get<MetricsTopCategory[]>(`/admin/metrics/top-categories?limit=5`),
+  });
+
+  const topHostsQuery = useQuery({
+    queryKey: ['metrics-top-hosts'],
+    queryFn: () => api.get<MetricsTopHost[]>(`/admin/metrics/top-hosts?limit=5`),
+  });
+
+  const fraudStatsQuery = useQuery({
+    queryKey: ['insights-fraud-stats'],
+    queryFn: () => api.get<FraudStats>('/insights/fraud-stats'),
+  });
+
+  if (metricsQuery.isLoading) {
+    return <div className="card">Cargando métricas…</div>;
+  }
+
+  if (metricsQuery.isError) {
+    return <div className="card card--error">Error al cargar métricas: {(metricsQuery.error as Error).message}</div>;
+  }
+
+  const metrics = metricsQuery.data;
+
+  return (
+    <div className="stack stack--lg">
+      <section className="grid grid--metrics">
+        <MetricCard title="Reportes totales" value={formatNumber(metrics.totalReports)} helper={`${formatNumber(metrics.approvedReports)} aprobados`} />
+        <MetricCard title="Reportes pendientes" value={formatNumber(metrics.pendingReports)} helper={`${formatNumber(metrics.totalFlags)} alertas abiertas`} />
+        <MetricCard title="Usuarios" value={formatNumber(metrics.totalUsers)} helper={`${formatNumber(metrics.blockedUsers)} bloqueados`} />
+        <MetricCard title="Alertas validadas" value={formatNumber(metrics.validatedFlags)} helper={`${formatNumber(metrics.dismissedFlags)} descartadas`} />
+      </section>
+
+      <section className="card">
+        <h2 className="card__title">Actividad reciente</h2>
+        {fraudStatsQuery.isLoading && <p>Cargando tendencias…</p>}
+        {fraudStatsQuery.isError && (
+          <p className="card__error">No se pudieron obtener las estadísticas: {(fraudStatsQuery.error as Error).message}</p>
+        )}
+        {fraudStatsQuery.data && (
+          <div className="grid grid--stats">
+            <div>
+              <p className="stat__label">Tiempo promedio de detección</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.averageDetectionDays)} días</p>
+            </div>
+            <div>
+              <p className="stat__label">Reportes aprobados</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.totalReportsApproved)}</p>
+            </div>
+            <div>
+              <p className="stat__label">Reportes esta semana</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.reportsThisWeek)}</p>
+            </div>
+            <div>
+              <p className="stat__label">Reportes este mes</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.reportsThisMonth)}</p>
+            </div>
+            <div>
+              <p className="stat__label">Usuarios activos</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.totalActiveUsers)}</p>
+            </div>
+            <div>
+              <p className="stat__label">Categorías activas</p>
+              <p className="stat__value">{formatNumber(fraudStatsQuery.data.categoriesCount)}</p>
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="grid grid--two-cols">
+        <article className="card">
+          <h2 className="card__title">Categorías con más actividad</h2>
+          {topCategoriesQuery.isLoading && <p>Cargando categorías…</p>}
+          {topCategoriesQuery.isError && (
+            <p className="card__error">No se pudieron obtener las categorías: {(topCategoriesQuery.error as Error).message}</p>
+          )}
+          {topCategoriesQuery.data && (
+            <ul className="list">
+              {topCategoriesQuery.data.map((category) => (
+                <li key={category.id} className="list__item">
+                  <div>
+                    <p className="list__title">{category.name}</p>
+                    <p className="list__subtitle">Slug: {category.slug}</p>
+                  </div>
+                  <div className="list__meta">
+                    <span>{formatNumber(category.reportsCount)} reportes</span>
+                    <span>{formatNumber(category.searchCount)} búsquedas</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+
+        <article className="card">
+          <h2 className="card__title">Hosts más reportados</h2>
+          {topHostsQuery.isLoading && <p>Cargando hosts…</p>}
+          {topHostsQuery.isError && (
+            <p className="card__error">No se pudieron obtener los hosts: {(topHostsQuery.error as Error).message}</p>
+          )}
+          {topHostsQuery.data && (
+            <ul className="list">
+              {topHostsQuery.data.map((host) => (
+                <li key={host.host} className="list__item">
+                  <div>
+                    <p className="list__title">{host.host || 'Host desconocido'}</p>
+                    <p className="list__subtitle">{formatNumber(host.reportsCount)} reportes totales</p>
+                  </div>
+                  <div className="list__meta">
+                    <span>{formatNumber(host.approvedReportsCount)} aprobados</span>
+                    <span>{formatNumber(host.pendingReportsCount)} pendientes</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </article>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,62 @@
+import { FormEvent, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+export function LoginPage() {
+  const { login, loading } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await login({ email, password });
+      const redirectTo =
+        ((location.state as { from?: { pathname?: string } } | null)?.from?.pathname) ?? '/dashboard';
+      navigate(redirectTo, { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo iniciar sesión');
+    }
+  };
+
+  return (
+    <div className="login">
+      <div className="login__card">
+        <h1 className="login__title">oFraud | Consola administrativa</h1>
+        <p className="login__subtitle">Autentícate con tus credenciales de administrador</p>
+        <form className="login__form" onSubmit={handleSubmit}>
+          <label className="login__label">
+            Correo electrónico
+            <input
+              className="login__input"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder="admin@ofraud.test"
+              required
+            />
+          </label>
+          <label className="login__label">
+            Contraseña
+            <input
+              className="login__input"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              placeholder="••••••••"
+              required
+            />
+          </label>
+          {error && <p className="login__error">{error}</p>}
+          <button className="button button--primary" type="submit" disabled={loading}>
+            {loading ? 'Verificando…' : 'Ingresar'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ReportFlagsPage.tsx
+++ b/frontend/src/pages/ReportFlagsPage.tsx
@@ -1,0 +1,167 @@
+import { useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useApi } from '../hooks/useApi';
+import type { AdminReportFlagsResponse, ReportFlagStatus } from '../api/types';
+import { StatusBadge } from '../components/StatusBadge';
+import { formatDateTime } from '../utils/format';
+import { Pagination } from '../components/Pagination';
+
+const flagStatusOptions: Array<{ value: ReportFlagStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'Todos' },
+  { value: 'pending', label: 'Pendientes' },
+  { value: 'validated', label: 'Validados' },
+  { value: 'dismissed', label: 'Descartados' },
+];
+
+export function ReportFlagsPage() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<ReportFlagStatus | 'all'>('pending');
+  const [page, setPage] = useState(1);
+  const limit = 10;
+  const [error, setError] = useState<string | null>(null);
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('limit', String(limit));
+    if (status !== 'all') {
+      params.set('status', status);
+    }
+    return params.toString();
+  }, [page, status]);
+
+  const flagsQuery = useQuery({
+    queryKey: ['admin-report-flags', queryString],
+    queryFn: () => api.get<AdminReportFlagsResponse>(`/admin/report-flags?${queryString}`),
+  });
+
+  const updateFlagStatus = async (flagId: number, newStatus: ReportFlagStatus) => {
+    setError(null);
+    try {
+      await api.patch(`/admin/report-flags/${flagId}`, { status: newStatus });
+      await queryClient.invalidateQueries({ queryKey: ['admin-report-flags'] });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo actualizar la alerta');
+    }
+  };
+
+  return (
+    <section className="card">
+      <div className="card__header">
+        <div>
+          <h2 className="card__title">Alertas de la comunidad</h2>
+          <p className="card__subtitle">Gestiona los reportes de abuso y contenido sospechoso.</p>
+        </div>
+        <div className="card__filters">
+          <label className="card__label">
+            Estado
+            <select
+              className="card__select"
+              value={status}
+              onChange={(event) => {
+                setStatus(event.target.value as ReportFlagStatus | 'all');
+                setPage(1);
+              }}
+            >
+              {flagStatusOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      </div>
+
+      {flagsQuery.data && (
+        <div className="card__chips">
+          <span>Pendientes: {flagsQuery.data.counts.pending}</span>
+          <span>Validados: {flagsQuery.data.counts.validated}</span>
+          <span>Descartados: {flagsQuery.data.counts.dismissed}</span>
+        </div>
+      )}
+
+      {error && <p className="card__error">{error}</p>}
+
+      {flagsQuery.isLoading && <p>Cargando alertas…</p>}
+      {flagsQuery.isError && (
+        <p className="card__error">No se pudieron obtener las alertas: {(flagsQuery.error as Error).message}</p>
+      )}
+
+      {flagsQuery.data && flagsQuery.data.items.length === 0 && <p>No hay alertas registradas con el filtro aplicado.</p>}
+
+      {flagsQuery.data && flagsQuery.data.items.length > 0 && (
+        <div className="table-wrapper">
+          <table className="table">
+            <thead>
+              <tr>
+                <th>ID</th>
+                <th>Reporte</th>
+                <th>Motivo</th>
+                <th>Reportado por</th>
+                <th>Estado</th>
+                <th>Creado</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {flagsQuery.data.items.map((flag) => (
+                <tr key={flag.flagId}>
+                  <td>{flag.flagId}</td>
+                  <td>
+                    <strong>{flag.reportTitle ?? `Reporte #${flag.reportId}`}</strong>
+                    <p className="table__meta">Estado: {flag.reportStatus}</p>
+                  </td>
+                  <td>
+                    <p>{flag.reasonCode}</p>
+                    {flag.details && <p className="table__meta">{flag.details}</p>}
+                  </td>
+                  <td>
+                    <p>{flag.reporter.name ?? 'Anónimo'}</p>
+                    <p className="table__meta">{flag.reporter.email ?? 'sin correo'}</p>
+                  </td>
+                  <td>
+                    <StatusBadge status={flag.status} />
+                  </td>
+                  <td>{formatDateTime(flag.createdAt)}</td>
+                  <td>
+                    <div className="table__actions">
+                      {flag.status !== 'validated' && (
+                        <button
+                          className="button button--primary"
+                          type="button"
+                          onClick={() => updateFlagStatus(flag.flagId, 'validated')}
+                        >
+                          Validar
+                        </button>
+                      )}
+                      {flag.status !== 'dismissed' && (
+                        <button
+                          className="button button--ghost"
+                          type="button"
+                          onClick={() => updateFlagStatus(flag.flagId, 'dismissed')}
+                        >
+                          Descartar
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {flagsQuery.data && (
+        <Pagination
+          page={flagsQuery.data.meta.page}
+          limit={flagsQuery.data.meta.limit}
+          total={flagsQuery.data.meta.total}
+          onPageChange={setPage}
+        />
+      )}
+    </section>
+  );
+}

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,0 +1,230 @@
+import { FormEvent, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useApi } from '../hooks/useApi';
+import type { AdminReportsResponse, ReportStatus } from '../api/types';
+import { StatusBadge } from '../components/StatusBadge';
+import { formatDateTime } from '../utils/format';
+import { Modal } from '../components/Modal';
+import { Pagination } from '../components/Pagination';
+
+const statusOptions: Array<{ value: ReportStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'Todos' },
+  { value: 'pending', label: 'Pendientes' },
+  { value: 'approved', label: 'Aprobados' },
+  { value: 'rejected', label: 'Rechazados' },
+  { value: 'removed', label: 'Eliminados' },
+];
+
+export function ReportsPage() {
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const [status, setStatus] = useState<ReportStatus | 'all'>('pending');
+  const [page, setPage] = useState(1);
+  const [rejectContext, setRejectContext] = useState<{ reportId: number; note: string; reason: string }>({ reportId: 0, note: '', reason: '' });
+  const [isRejectOpen, setRejectOpen] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const limit = 10;
+
+  const queryString = useMemo(() => {
+    const params = new URLSearchParams();
+    params.set('page', String(page));
+    params.set('limit', String(limit));
+    if (status !== 'all') {
+      params.set('status', status);
+    }
+    return params.toString();
+  }, [page, status]);
+
+  const reportsQuery = useQuery({
+    queryKey: ['admin-reports', queryString],
+    queryFn: () => api.get<AdminReportsResponse>(`/admin/reports?${queryString}`),
+  });
+
+  const handleApprove = async (reportId: number) => {
+    setActionError(null);
+    try {
+      await api.post('/reports/moderate', { action: 'approve', reportId });
+      await queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'No se pudo aprobar el reporte');
+    }
+  };
+
+  const handleOpenReject = (reportId: number) => {
+    setRejectContext({ reportId, note: '', reason: '' });
+    setRejectOpen(true);
+  };
+
+  const handleReject = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setActionError(null);
+    try {
+      await api.post('/reports/moderate', {
+        action: 'reject',
+        reportId: rejectContext.reportId,
+        rejectionReasonText: rejectContext.reason || null,
+        note: rejectContext.note || null,
+      });
+      setRejectOpen(false);
+      await queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'No se pudo rechazar el reporte');
+    }
+  };
+
+  const handleRemove = async (reportId: number) => {
+    setActionError(null);
+    try {
+      await api.del(`/admin/reports/${reportId}`);
+      await queryClient.invalidateQueries({ queryKey: ['admin-reports'] });
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : 'No se pudo eliminar el reporte');
+    }
+  };
+
+  return (
+    <div className="stack stack--lg">
+      <section className="card">
+        <div className="card__header">
+          <div>
+            <h2 className="card__title">Moderación de reportes</h2>
+            <p className="card__subtitle">Aprueba, rechaza o elimina los reportes enviados por la comunidad.</p>
+          </div>
+          <div className="card__filters">
+            <label className="card__label">
+              Estado
+              <select
+                className="card__select"
+                value={status}
+                onChange={(event) => {
+                  setStatus(event.target.value as ReportStatus | 'all');
+                  setPage(1);
+                }}
+              >
+                {statusOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </div>
+
+        {actionError && <p className="card__error">{actionError}</p>}
+
+        {reportsQuery.isLoading && <p>Cargando reportes…</p>}
+        {reportsQuery.isError && (
+          <p className="card__error">Error al cargar los reportes: {(reportsQuery.error as Error).message}</p>
+        )}
+
+        {reportsQuery.data && reportsQuery.data.items.length === 0 && <p>No se encontraron reportes con el filtro seleccionado.</p>}
+
+        {reportsQuery.data && reportsQuery.data.items.length > 0 && (
+          <div className="table-wrapper">
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>Título</th>
+                  <th>Categoría</th>
+                  <th>Estado</th>
+                  <th>Autor</th>
+                  <th>Revisor</th>
+                  <th>Actualizado</th>
+                  <th>Acciones</th>
+                </tr>
+              </thead>
+              <tbody>
+                {reportsQuery.data.items.map((report) => (
+                  <tr key={report.reportId}>
+                    <td>{report.reportId}</td>
+                    <td>
+                      <strong>{report.title ?? 'Sin título'}</strong>
+                      <p className="table__meta">Creado: {formatDateTime(report.createdAt)}</p>
+                    </td>
+                    <td>{report.categoryName ?? 'Sin categoría'}</td>
+                    <td>
+                      <StatusBadge status={report.status} />
+                    </td>
+                    <td>
+                      <p>{report.author.name ?? 'Anónimo'}</p>
+                      <p className="table__meta">{report.author.email ?? 'sin correo'}</p>
+                    </td>
+                    <td>{report.reviewer?.name ?? '—'}</td>
+                    <td>{formatDateTime(report.updatedAt)}</td>
+                    <td>
+                      <div className="table__actions">
+                        {report.status === 'pending' && (
+                          <>
+                            <button className="button button--primary" type="button" onClick={() => handleApprove(report.reportId)}>
+                              Aprobar
+                            </button>
+                            <button
+                              className="button button--danger"
+                              type="button"
+                              onClick={() => handleOpenReject(report.reportId)}
+                            >
+                              Rechazar
+                            </button>
+                          </>
+                        )}
+                        {report.status !== 'removed' && (
+                          <button className="button button--ghost" type="button" onClick={() => handleRemove(report.reportId)}>
+                            Eliminar
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {reportsQuery.data && (
+          <Pagination
+            page={reportsQuery.data.meta.page}
+            limit={reportsQuery.data.meta.limit}
+            total={reportsQuery.data.meta.total}
+            onPageChange={setPage}
+          />
+        )}
+      </section>
+
+      <Modal open={isRejectOpen} title="Rechazar reporte" onClose={() => setRejectOpen(false)}>
+        <form className="form" onSubmit={handleReject}>
+          <label className="form__label">
+            Motivo del rechazo
+            <textarea
+              className="form__textarea"
+              value={rejectContext.reason}
+              onChange={(event) => setRejectContext((ctx) => ({ ...ctx, reason: event.target.value }))}
+              placeholder="Describe brevemente el motivo"
+              rows={3}
+            />
+          </label>
+          <label className="form__label">
+            Nota interna
+            <textarea
+              className="form__textarea"
+              value={rejectContext.note}
+              onChange={(event) => setRejectContext((ctx) => ({ ...ctx, note: event.target.value }))}
+              placeholder="Notas visibles solo para administradores"
+              rows={2}
+            />
+          </label>
+          <div className="form__actions">
+            <button className="button button--ghost" type="button" onClick={() => setRejectOpen(false)}>
+              Cancelar
+            </button>
+            <button className="button button--danger" type="submit">
+              Confirmar rechazo
+            </button>
+          </div>
+        </form>
+      </Modal>
+    </div>
+  );
+}

--- a/frontend/src/utils/format.ts
+++ b/frontend/src/utils/format.ts
@@ -1,0 +1,26 @@
+export function formatDate(dateIso: string | null | undefined) {
+  if (!dateIso) return '—';
+  const date = new Date(dateIso);
+  return new Intl.DateTimeFormat('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(date);
+}
+
+export function formatDateTime(dateIso: string | null | undefined) {
+  if (!dateIso) return '—';
+  const date = new Date(dateIso);
+  return new Intl.DateTimeFormat('es-ES', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date);
+}
+
+export function formatNumber(num: number | null | undefined) {
+  if (typeof num !== 'number' || Number.isNaN(num)) return '0';
+  return new Intl.NumberFormat('es-ES').format(num);
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    host: '0.0.0.0',
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vite + React frontend under `frontend/` to serve as the oFraud admin dashboard
- implement authentication, metrics, report moderation, flag handling, and category management flows powered by the existing REST API
- document dashboard usage in the README and ignore generated frontend artifacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32752b514832b8a12e76e6349cb70